### PR TITLE
Increase refresh rate by 25%

### DIFF
--- a/updated code
+++ b/updated code
@@ -478,8 +478,8 @@ function draw(){
 }
 
 function update(){
-  // movement step gating
-  player.stepCD = Math.max(0, player.stepCD-16);
+  // movement step gating (refresh 25% faster)
+  player.stepCD = Math.max(0, player.stepCD-20);
   let moved=false;
   if(player.stepCD<=0){
     let dx=0, dy=0;


### PR DESCRIPTION
## Summary
- Speed up the game's refresh by reducing step cooldown decrement to 20 (25% faster)

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca9ed9ce88322a24b807f1d861165