### PR TITLE
Move gold drops to monster death

### DIFF
--- a/dungeon_smooth_diagonal_toggle_single_file_html.html
+++ b/dungeon_smooth_diagonal_toggle_single_file_html.html
@@ -239,7 +239,7 @@ function monsterStep(m){
     }else{
       m.rx=m.x; m.ry=m.y; m.moving=false; m.moveT=1;
     }
-    if(rng.next()<LOOT_CHANCE*0.04) dropLoot(nx,ny);
+    // Removed per-step gold drops to prevent excessive loot spawning.
   }
   m.cd=rng.int(2,8);
 }
@@ -283,7 +283,12 @@ function draw(dt){
     ctx.fillStyle='#111'; ctx.fillRect(mx, my-6, 24, 3);
     ctx.fillStyle='#e33'; const hw=24*(Math.max(0,m.hp)/m.hpMax); ctx.fillRect(mx, my-6, hw, 3);
     if(m.hitFlash>0) m.hitFlash--;
-    if(m.hp<=0){ if(Math.random()<0.3) dropLoot(m.x,m.y); const idx=monsters.indexOf(m); if(idx>=0) monsters.splice(idx,1); }
+    if(m.hp<=0){
+      // Drop gold when a monster dies instead of during movement.
+      dropLoot(m.x,m.y);
+      const idx=monsters.indexOf(m);
+      if(idx>=0) monsters.splice(idx,1);
+    }
   }
 
   // player


### PR DESCRIPTION
## Summary
- Remove step-based gold drops from monsters
- Drop gold when a monster dies instead

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc1938bb883228d7b2d7aa3d4ad68