### PR TITLE
Enable inventory panel toggle and refresh

### DIFF
--- a/dungeon_smooth_diagonal_toggle_single_file_html.html
+++ b/dungeon_smooth_diagonal_toggle_single_file_html.html
@@ -382,7 +382,13 @@ window.addEventListener('keypress',e=>{
 });
 
 // ===== Inventory UI (toggle only) =====
-function toggleInv(){ /* panel elided; still toggled by I */ }
+function toggleInv(){
+  const panel=document.getElementById('inv');
+  if(!panel) return;
+  const show=panel.style.display===''||panel.style.display==='none';
+  panel.style.display=show?'block':'none';
+  if(show) redrawInventory();
+}
 
 // ===== Loot helpers =====
 function dropLoot(x,y){ lootMap.set(`${x},${y}`,{color:'#ffd24a',type:'gold',amt:rng.int(4,10)}); }


### PR DESCRIPTION
## Summary
- Make inventory toggle function show or hide the panel and refresh its contents
- Keep key handler linking `I` key presses to `toggleInv`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc18fb90c832284102d70539927ea