### PR TITLE
Restrict loot drops to monster death

### DIFF
--- a/dungeon_smooth_diagonal_toggle_single_file_html.html
+++ b/dungeon_smooth_diagonal_toggle_single_file_html.html
@@ -74,6 +74,7 @@
 // ===== Config / Globals =====
 const VIEW_W=1280, VIEW_H=720;
 const TILE=32, MAP_W=48, MAP_H=48; const MONSTER_COUNT=24; const FOV_RADIUS=8; const LOOT_CHANCE=0.18;
+const MONSTER_LOOT_CHANCE=0.3; // chance for a monster to drop loot on death
 let canvas=document.getElementById('gameCanvas'); let ctx=canvas.getContext('2d');
 let camX=0, camY=0; let floorLayer=null, wallLayer=null;
 let floorTex=(function(){ const c=document.createElement('canvas'); c.width=c.height=64; const g=c.getContext('2d'); g.fillStyle='#151821'; g.fillRect(0,0,64,64); g.fillStyle='rgba(255,255,255,0.03)'; for(let i=0;i<120;i++){ g.fillRect((Math.random()*64)|0,(Math.random()*64)|0,1,1);} return c; })();
@@ -332,8 +333,8 @@ function draw(dt){
     ctx.fillStyle='#e33'; const hw=24*(Math.max(0,m.hp)/m.hpMax); ctx.fillRect(mx, my-6, hw, 3);
     if(m.hitFlash>0) m.hitFlash--;
     if(m.hp<=0){
-      // Drop gold when a monster dies instead of during movement.
-      dropLoot(m.x,m.y);
+      // Drop loot only on death with a chance
+      if(Math.random()<MONSTER_LOOT_CHANCE) dropLoot(m.x,m.y);
       const idx=monsters.indexOf(m);
       if(idx>=0) monsters.splice(idx,1);
     }

--- a/updated code
+++ b/updated code
@@ -95,7 +95,7 @@ const MAP_W=90, MAP_H=70;
 const FOV_RADIUS=11;
 const ROOM_COUNT=24;
 const MONSTER_COUNT=16;
-const LOOT_CHANCE=0.18;
+const LOOT_CHANCE=0.3; // chance for loot to drop when a monster dies
 const VIEW_W=1280, VIEW_H=720;
 
 let camX=0, camY=0;
@@ -385,7 +385,7 @@ function monsterStep(m){
   if(m.cd>0){ m.cd--; return; }
   const dirs=[[1,0],[-1,0],[0,1],[0,-1],[0,0]]; const d=dirs[rng.int(0,dirs.length-1)];
   const nx=m.x+d[0], ny=m.y+d[1];
-  if(nx>=0&&ny>=0&&nx<MAP_W&&ny<MAP_H && map[ny*MAP_W+nx]!==T_WALL && map[ny*MAP_W+nx]!==T_EMPTY){ m.x=nx; m.y=ny; if(rng.next()<LOOT_CHANCE*0.04) dropLoot(nx,ny); }
+  if(nx>=0&&ny>=0&&nx<MAP_W&&ny<MAP_H && map[ny*MAP_W+nx]!==T_WALL && map[ny*MAP_W+nx]!==T_EMPTY){ m.x=nx; m.y=ny; }
   m.cd=rng.int(2,8);
 }
 function dist(a,b){ return Math.abs(a.x-b.x)+Math.abs(a.y-b.y); }
@@ -453,7 +453,7 @@ function draw(){
     if(m.hitFlash>0) m.hitFlash--;
     if(m.hp<=0){
       // death
-      if(Math.random()<0.3) dropLoot(m.x,m.y);
+      if(Math.random()<LOOT_CHANCE) dropLoot(m.x,m.y);
       const idx=monsters.indexOf(m); if(idx>=0) monsters.splice(idx,1);
     }
   }


### PR DESCRIPTION
## Summary
- remove random loot drops during monster movement
- add configurable chance for loot drops on monster death

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68acc46a0df48322820379c921b9097d