### PR TITLE
feat: add elemental resists and caster enemy

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,6 +233,19 @@ function genSprites(){
     outline(g,S);
   });
 
+  // Mage/Cultist 24x24 (caster enemy)
+  SPRITES.mage = makeSprite(24,(g,S)=>{
+    // robe
+    px(g,6,8,12,10,'#4a3a7e'); px(g,8,6,8,3,'#4a3a7e');
+    // trim
+    px(g,6,16,12,2,'#b84aff');
+    // head
+    px(g,8,2,8,4,'#e6c9a6'); px(g,9,3,2,2,'#000'); px(g,13,3,2,2,'#000');
+    // staff/glow
+    px(g,3,6,2,14,'#7a5cff'); px(g,2,6,4,2,'#b84aff');
+    outline(g,S);
+  });
+
   // Stairs (down) 24x24
   SPRITES.stairs = makeSprite(24,(g,S)=>{
     // tile base
@@ -289,9 +302,11 @@ let playerSpriteKey = 'player_m';
 // Monsters now have richer AI with per-type patterns and scaling
 // {x,y,rx,ry,type,hp,hpMax,dmgMin,dmgMax,atkCD,moveCD,state:{...},hitFlash}
 let monsters=[];
-// Simple projectile pool for ranged attacks (e.g., skeleton arrows)
-// {x,y,dx,dy,speed,damage,alive}
+// Simple projectile pool for ranged/magic attacks
+// {x,y,dx,dy,speed,damage,type,alive}
 let projectiles=[];
+// floating combat text
+let damageTexts=[];
 const SLOTS=["helmet","chest","legs","hands","feet","weapon"];
 let equip={helmet:null,chest:null,legs:null,hands:null,feet:null,weapon:null};
 const BAG_SIZE=12; let bag=new Array(BAG_SIZE).fill(null);
@@ -355,7 +370,7 @@ function generate(){
     const r=rooms[rng.int(0,rooms.length-1)];
     const x=rng.int(r.x+1,r.x+r.w-2), y=rng.int(r.y+1,r.y+r.h-2);
     if((x===player.x && y===player.y) || (x===merchant.x && y===merchant.y)) continue;
-    const t=rng.int(0,2); // 0=slime(melee), 1=bat(swoop), 2=skeleton(ranged)
+    const t=rng.int(0,3); // 0=slime, 1=bat, 2=skeleton, 3=mage
     monsters.push(spawnMonster(t,x,y));
   }
 
@@ -376,6 +391,7 @@ function spawnMonster(type,x,y){
     { hp:16, dmg:[2,4], atkCD:28, moveCD:[6,10] },    // slime: sturdy melee
     { hp:12, dmg:[1,3], atkCD:22, moveCD:[4,8] },     // bat: fast swoop
     { hp:14, dmg:[2,5], atkCD:38, moveCD:[6,10] },    // skeleton: ranged
+    { hp:12, dmg:[3,6], atkCD:30, moveCD:[6,10] },    // mage: caster (magic)
   ];
   const a = archetypes[type] || archetypes[0];
   const m = {
@@ -401,6 +417,18 @@ function clearPathCardinal(x1,y1,x2,y2){
   while(!(x===x2 && y===y2)){
     if(isBlock(x,y)) return false;
     x+=dx; y+=dy;
+  }
+  return true;
+}
+// 8-directional LoS (grid step); simple check for caster
+function clearPath8(x1,y1,x2,y2){
+  let dx = sign(x2-x1), dy = sign(y2-y1);
+  if(dx===0 && dy===0) return true;
+  let x=x1+dx, y=y1+dy;
+  while(!(x===x2 && y===y2)){
+    if(isBlock(x,y)) return false;
+    if(x!==x2) x+=dx;
+    if(y!==y2) y+=dy;
   }
   return true;
 }
@@ -448,6 +476,11 @@ function affixMods(slot){
   const R={};
   if(slot==='weapon'){ R.dmgMin=(rng.int(0,2)); R.dmgMax=(rng.int(1,4)); if(rng.next()<0.25) R.crit=rng.int(2,6); }
   if(slot!=='weapon'){ if(rng.next()<0.5) R.armor=rng.int(1,4); }
+  // elemental/magic resists are more common on armor
+  if(slot!=='weapon'){ if(rng.next()<0.30) R.resFire=rng.int(2,10); }
+  if(slot!=='weapon'){ if(rng.next()<0.30) R.resIce=rng.int(2,10); }
+  if(slot!=='weapon'){ if(rng.next()<0.30) R.resShock=rng.int(2,10); }
+  if(rng.next()<0.18) R.resMagic=rng.int(2,12);
   if(rng.next()<0.3) R.hpMax=rng.int(5,20);
   if(rng.next()<0.2) R.mpMax=rng.int(5,15);
   if(rng.next()<0.2) R.speedPct=rng.int(2,8);
@@ -565,6 +598,8 @@ function shortMods(it){ const m=it.mods||{}; const bits=[];
   if(m.speedPct) bits.push(`SPD+${m.speedPct}%`);
   if(m.ls) bits.push(`LS ${m.ls}%`);
   if(m.mp) bits.push(`MPo+${m.mp}`);
+  const rf=m.resFire||0, ri=m.resIce||0, rs=m.resShock||0, rm=m.resMagic||0;
+  if(rf||ri||rs||rm) bits.push(`RES F/I/S/M ${rf}/${ri}/${rs}/${rm}`);
   return bits.join(' · ');
 }
 
@@ -582,6 +617,9 @@ function renderDetails(it, origin){
   if(m.speedPct) rows.push(`<div>Speed: <span class="mono">+${m.speedPct}%</span></div>`);
   if(m.ls) rows.push(`<div>Lifesteal: <span class="mono">${m.ls}%</span></div>`);
   if(m.mp) rows.push(`<div>Mana on hit: <span class="mono">+${m.mp}</span></div>`);
+  if(m.resFire||m.resIce||m.resShock||m.resMagic){
+    rows.push(`<div>Resists (F/I/S/M): <span class="mono">${m.resFire||0}/${m.resIce||0}/${m.resShock||0}/${m.resMagic||0}%</span></div>`);
+  }
   if(rows.length===0) rows.push('<div class="muted">No magical properties.</div>');
   lines.push(`<div style="margin:6px 0">${rows.join('')}</div>`);
   lines.push(`<div class="kv"><span class="pill">Value ${val}</span><span class="pill">Sell ${sell}</span>${origin==='shop'?'<span class="pill">Buy</span>':''}</div>`);
@@ -597,6 +635,7 @@ function getItemValue(it){
   score+= (m.crit||0)*3 + (m.armor||0)*3;
   score+= (m.hpMax||0)*0.8 + (m.mpMax||0)*0.6 + (m.speedPct||0)*4;
   score+= (m.ls||0)*6 + (m.mp||0)*2;
+  score+= ((m.resFire||0)+(m.resIce||0)+(m.resShock||0))*1.2 + (m.resMagic||0)*1.8;
   const floorBonus = Math.max(0,floorNum-1)*4;
   return Math.max(5, Math.floor((rBase + score)*slotFactor + floorBonus));
 }
@@ -675,9 +714,25 @@ function currentAtk(){
   const w=equip.weapon?.mods||{}; min+=w.dmgMin||0; max+=w.dmgMax||0; crit += w.crit||0; ls=w.ls||0; return {min,max,crit,ls};
 }
 
-function applyDamageToPlayer(dmg){
-  // future: include armor/resists here if you add them
-  player.hp = Math.max(0, player.hp - Math.max(1, dmg));
+function applyDamageToPlayer(dmg, type='physical'){
+  // Armor DR (applies to physical/ranged only)
+  const armor = player.armor||0;
+  const K = 50 + 10 * Math.max(0, floorNum-1);
+  const armorDR = Math.max(0, Math.min(0.8, armor / (armor + K)));
+  let afterArmor = dmg;
+  if(type==='physical' || type==='ranged'){ afterArmor = Math.max(1, Math.floor(dmg * (1 - armorDR))); }
+
+  // Elemental/magic resist (percentage, capped)
+  const cap = 75;
+  const rF = clamp(0, cap, player.resFire||0);
+  const rI = clamp(0, cap, player.resIce||0);
+  const rS = clamp(0, cap, player.resShock||0);
+  const rM = clamp(0, cap, player.resMagic||0);
+  const resPct = (type==='fire')?rF : (type==='ice')?rI : (type==='shock')?rS : (type==='magic')?rM : 0;
+  const eff = Math.max(1, Math.floor(afterArmor * (1 - resPct/100)));
+
+  player.hp = Math.max(0, player.hp - eff);
+  damageTexts.push({ tx:player.x, ty:player.y, text:`-${eff}`, color:(type==='magic'?'#b84aff':'#ff6b6b'), age:0, ttl:900 });
   if(player.hp===0){ showToast('You died… Press E on stairs next time 😅'); }
 }
 
@@ -752,17 +807,34 @@ function monsterAI(m, dt){
       }
       m.moveCD = rng.int(4, 8);
     }
-  } else { // Skeleton — ranged: shoot if LoS, otherwise shuffle toward
+  } else if(m.type===2) { // Skeleton — ranged: shoot if LoS, otherwise shuffle toward
     if(manhattan<=7 && clearPathCardinal(m.x,m.y,player.x,player.y) && m.atkCD===0){
       // fire arrow
       const adx = sign(player.x - m.x), ady = sign(player.y - m.y);
-      projectiles.push({ x:m.x+0.5, y:m.y+0.5, dx:adx, dy:ady, speed:10/1000, damage:rng.int(m.dmgMin,m.dmgMax), alive:true });
+      projectiles.push({ x:m.x+0.5, y:m.y+0.5, dx:adx, dy:ady, speed:10/1000, damage:rng.int(m.dmgMin,m.dmgMax), type:'ranged', alive:true });
       m.atkCD = rng.int(26, 40);
       return;
     }
     if(m.moveCD===0){
       // slow shuffle
       if(!tryMoveMonster(m, dx, 0, 160)) tryMoveMonster(m, 0, dy, 160);
+      m.moveCD = rng.int(6, 10);
+    }
+  } else { // Mage — caster: maintain distance, shoot magic bolts with 8-dir LoS
+    const preferRange = 5; // keep around 4-6 tiles away
+    if(manhattan<=8 && clearPath8(m.x,m.y,player.x,player.y) && m.atkCD===0){
+      const adx = sign(player.x - m.x), ady = sign(player.y - m.y);
+      projectiles.push({ x:m.x+0.5, y:m.y+0.5, dx:adx, dy:ady, speed:8/1000, damage:rng.int(m.dmgMin,m.dmgMax+2), type:'magic', alive:true });
+      m.atkCD = rng.int(24, 34);
+      return;
+    }
+    if(m.moveCD===0){
+      // too close -> step away; too far/blocked -> step toward
+      if(manhattan<=preferRange-1){
+        if(!tryMoveMonster(m, -dx, 0, 150)) tryMoveMonster(m, 0, -dy, 150);
+      }else{
+        if(!tryMoveMonster(m, dx, 0, 150)) tryMoveMonster(m, 0, dy, 150);
+      }
       m.moveCD = rng.int(6, 10);
     }
   }
@@ -807,7 +879,7 @@ function draw(dt){
     const mtx = (m.rx!==undefined ? m.rx : m.x);
     const mty = (m.ry!==undefined ? m.ry : m.y);
     const mx = mtx*TILE - camX + (TILE-24)/2; const my = mty*TILE - camY + (TILE-24)/2;
-    const key = m.type===0?'slime': (m.type===1?'bat':'skeleton');
+    const key = m.type===0?'slime' : m.type===1?'bat' : m.type===2?'skeleton' : 'mage';
     ctx.drawImage(SPRITES[key].cv, mx, my);
     if(m.hitFlash>0){ ctx.globalAlpha=0.5; ctx.fillStyle='#ff6666'; ctx.fillRect(mx,my,24,24); ctx.globalAlpha=1; }
     // hp bar
@@ -826,7 +898,7 @@ function draw(dt){
   for(const p of projectiles){
     if(!p.alive) continue;
     const px = p.x*TILE - camX - 3, py = p.y*TILE - camY - 3;
-    ctx.fillStyle = '#ffd24a';
+    ctx.fillStyle = (p.type==='magic') ? '#b84aff' : '#ffd24a';
     ctx.fillRect(px, py, 6, 6);
   }
 
@@ -835,6 +907,17 @@ function draw(dt){
   const pty = (smoothEnabled && player.ry!==undefined ? player.ry : player.y);
   const px = ptx*TILE - camX + (TILE-24)/2; const py = pty*TILE - camY + (TILE-24)/2;
   ctx.drawImage(SPRITES[playerSpriteKey].cv, px, py);
+
+  // floating damage texts
+  for(const t of damageTexts){
+    const tx = t.tx*TILE - camX;
+    const ty = t.ty*TILE - camY - (t.age/100)*20;
+    ctx.fillStyle = t.color || '#ff6b6b';
+    ctx.font = 'bold 14px sans-serif';
+    ctx.fillText(t.text, tx+8, ty);
+    t.age += dt;
+  }
+  damageTexts = damageTexts.filter(t=>t.age < t.ttl);
 
   // fog
   ctx.fillStyle='#000';
@@ -908,7 +991,7 @@ function update(dt){
     if(isBlock(tx,ty)){ p.alive=false; continue; }
     // hit player if sharing tile
     if(tx===player.x && ty===player.y){
-      applyDamageToPlayer(p.damage);
+      applyDamageToPlayer(p.damage, p.type||'ranged');
       p.alive=false;
     }
   }
@@ -952,15 +1035,19 @@ let toastTimer=0; function showToast(msg){ const bar=document.querySelector('.to
 // ===== Stats =====
 function recalcStats(){
   let dmgMin=2,dmgMax=4,crit=5,armor=0; let hpMax=100, mpMax=60, speedPct=0;
+  let resF=0,resI=0,resS=0,resM=0;
   // level bonus
   const lvlBonus = Math.floor((player.lvl-1)*0.6) + (player.baseAtkBonus||0);
   dmgMin += lvlBonus; dmgMax += lvlBonus;
   for(const slot of SLOTS){
     const it=equip[slot]; if(!it) continue; const m=it.mods;
     if(m.dmgMin) dmgMin+=m.dmgMin; if(m.dmgMax) dmgMax+=m.dmgMax; if(m.crit) crit+=m.crit; if(m.armor) armor+=m.armor; if(m.hpMax) hpMax+=m.hpMax; if(m.mpMax) mpMax+=m.mpMax; if(m.speedPct) speedPct+=m.speedPct;
+    resF += m.resFire||0; resI += m.resIce||0; resS += m.resShock||0; resM += m.resMagic||0;
   }
   player.hpMax=hpMax; player.mpMax=mpMax; player.speedPct=speedPct; if(player.hp>hpMax) player.hp=hpMax; if(player.mp>mpMax) player.mp=mpMax;
-  hudDmg.textContent = `ATK ${dmgMin}-${dmgMax} | CRIT ${crit}% | ARM ${armor}`;
+  player.armor = armor;
+  player.resFire=resF; player.resIce=resI; player.resShock=resS; player.resMagic=resM;
+  hudDmg.textContent = `ATK ${dmgMin}-${dmgMax} | CRIT ${crit}% | ARM ${armor} | RES F/I/S/M ${resF}/${resI}/${resS}/${resM}`;
   hpFill.style.width = `${(player.hp/player.hpMax)*100}%`; mpFill.style.width = `${(player.mp/player.mpMax)*100}%`;
   hpLbl.textContent = `HP ${player.hp}/${player.hpMax}`; mpLbl.textContent = `Mana ${player.mp}/${player.mpMax}`;
 }


### PR DESCRIPTION
## Summary
- add mage/cultist caster with magic bolts and 8-dir line-of-sight
- expand gear with elemental and magic resistance affixes
- show resistances in HUD and apply during damage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acfcc1b7ec832290593f49eae694af