### PR TITLE
fix: enable left click attack

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,6 +770,8 @@ function drawStatusPips(ctx, entity, cx, cy){
 
 // ===== Combat / Click =====
 canvas.addEventListener('mousedown', (e)=>{
+  if(e.button !== 0) return; // ensure left-click
+  e.preventDefault();
   // face toward click and attack
   const rect=canvas.getBoundingClientRect(); const mx=(e.clientX-rect.left); const my=(e.clientY-rect.top);
   const px = player.rx!==undefined?player.rx:player.x, py = player.ry!==undefined?player.ry:player.y;


### PR DESCRIPTION
## Summary
- ensure attack handler responds only to left mouse button
- prevent default browser actions when initiating an attack

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad098d8d70832282e0ee9bf5fce85b