### PR TITLE
Rebalance player and monster health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with date-based entries.
 
 ## [Unreleased]
-- (Add planned changes here)
+### Changed
+- Increased player starting health by 50 points.
+- Reduced base health of all monster types.
 
 ## 2025-08-26
 ### Added

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@ genSprites();
 let seed=(Math.random()*1e9)|0, floorNum=1, rng=new RNG(seed);
 let map=[], fog=[], vis=[]; let rooms=[]; let stairs={x:0,y:0};
 let merchant={x:0,y:0}; let merchantStyle = Math.random()<0.5 ? 'goblin' : 'stall';
-let player={x:0,y:0,hp:100,hpMax:100,mp:60,mpMax:60,gold:0,stepCD:0,stepDelay:140,speedPct:0,lvl:1,xp:0,xpToNext:50,baseAtkBonus:0, gender:'m', atkCD:0, faceDx:1, faceDy:0, effects:[]};
+let player={x:0,y:0,hp:150,hpMax:150,mp:60,mpMax:60,gold:0,stepCD:0,stepDelay:140,speedPct:0,lvl:1,xp:0,xpToNext:50,baseAtkBonus:0, gender:'m', atkCD:0, faceDx:1, faceDy:0, effects:[]};
 let playerSpriteKey = 'player_m';
 // Monsters now have richer AI with per-type patterns and scaling
 // {x,y,rx,ry,type,hp,hpMax,dmgMin,dmgMax,atkCD,moveCD,state:{...},hitFlash,effects:[]}
@@ -411,10 +411,10 @@ function scaleStat(base, perFloor){ return Math.max(1, Math.floor(base + perFloo
 function spawnMonster(type,x,y){
   // Base stats per archetype
   const archetypes = [
-    { hp:24, dmg:[2,4], atkCD:28, moveCD:[6,10] },    // slime: sturdy melee, high HP
-    { hp:8,  dmg:[1,3], atkCD:22, moveCD:[4,8] },     // bat: frail but fast
-    { hp:18, dmg:[2,5], atkCD:38, moveCD:[6,10] },    // skeleton: durable ranged
-    { hp:14, dmg:[3,6], atkCD:30, moveCD:[6,10] },    // mage: caster with moderate HP
+    { hp:18, dmg:[2,4], atkCD:28, moveCD:[6,10] },    // slime: sturdy melee, high HP
+    { hp:6,  dmg:[1,3], atkCD:22, moveCD:[4,8] },     // bat: frail but fast
+    { hp:14, dmg:[2,5], atkCD:38, moveCD:[6,10] },    // skeleton: durable ranged
+    { hp:11, dmg:[3,6], atkCD:30, moveCD:[6,10] },    // mage: caster with moderate HP
   ];
   const a = archetypes[type] || archetypes[0];
   const diff = 1 + SCALE.HARDNESS_MULT * Math.max(0, floorNum-1);
@@ -1241,7 +1241,7 @@ function showRespawn(){ gameOver=true; const d=document.getElementById('respawn'
 
 // ===== Stats =====
 function recalcStats(){
-  let dmgMin=2,dmgMax=4,crit=5,armor=0; let hpMax=100, mpMax=60, speedPct=0;
+  let dmgMin=2,dmgMax=4,crit=5,armor=0; let hpMax=150, mpMax=60, speedPct=0;
   let resF=0,resI=0,resS=0,resM=0;
   // level bonus
   const lvlBonus = Math.floor((player.lvl-1)*0.6) + (player.baseAtkBonus||0);


### PR DESCRIPTION
## Summary
- increase player starting health by 50 points
- lower base health for all monster types
- document health adjustments in changelog

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad156cda108322949439b7a291a053