### PR TITLE
Add quick-use potion hotkeys for 1-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Then visit [http://localhost:8000](http://localhost:8000).
 - **WASD or Arrow Keys** – Move in eight directions
 - **I** – Toggle inventory
 - **E** – Use stairs or the merchant
+- **1/2/3** – Quick-use potion from bag slot 1–3
 - **Click monsters** – Attack
 
 ## Development Notes

--- a/index.html
+++ b/index.html
@@ -1289,7 +1289,21 @@ function update(dt){
 
 // ===== Input =====
 const keys={};
-window.addEventListener('keydown',e=>{ keys[e.key]=true; if(e.key==='i'||e.key==='I') toggleInv(); });
+window.addEventListener('keydown',e=>{
+  keys[e.key]=true;
+  if(e.key==='i'||e.key==='I') toggleInv();
+  // quick-use potions from bag slots with number keys 1-3
+  if(e.key==='1'||e.key==='2'||e.key==='3'){
+    const idx = parseInt(e.key,10)-1;
+    const it = bag[idx];
+    if(it && it.type==='potion'){
+      usePotion(it);
+      bag[idx]=null;
+      const panel=document.getElementById('inventory');
+      if(panel && panel.style.display==='block') redrawInventory();
+    }
+  }
+});
 // Space to attack in facing direction
 window.addEventListener('keydown',e=>{ if(e.code==='Space'){ performPlayerAttack(player.faceDx, player.faceDy); } });
 window.addEventListener('keyup',e=>{ keys[e.key]=false; });


### PR DESCRIPTION
## Summary
- Map number keys 1–3 to quick-use potions from matching bag slots
- Document new potion hotkeys in controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1b95ba848322b9f43b11dd01e19d