### PR TITLE
Add dedicated potion bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then visit [http://localhost:8000](http://localhost:8000).
 - **WASD or Arrow Keys** – Move in eight directions
 - **I** – Toggle inventory
 - **E** – Use stairs or the merchant
-- **1/2/3** – Quick-use potion from bag slot 1–3
+- **1/2/3** – Quick-use potion from potion bag slot 1–3
 - **Click monsters** – Attack
 
 ## Development Notes

--- a/index.html
+++ b/index.html
@@ -327,6 +327,7 @@ function addDamageText(tx,ty,text,color){ damageTexts.push({ tx, ty, text, color
 const SLOTS=["helmet","chest","legs","hands","feet","weapon"];
 let equip={helmet:null,chest:null,legs:null,hands:null,feet:null,weapon:null};
 const BAG_SIZE=12; let bag=new Array(BAG_SIZE).fill(null);
+const POTION_BAG_SIZE=3; let potionBag=new Array(POTION_BAG_SIZE).fill(null);
 let shopStock=[];
 
 // HUD refs
@@ -556,6 +557,13 @@ function pickupHere(){
   if(it.type === 'gold'){
     player.gold += it.amt; hudGold.textContent = player.gold; showToast(`+${it.amt} gold`); lootMap.delete(key); return;
   }
+  if(it.type === 'potion'){
+    const pidx = potionBag.findIndex(b=>!b);
+    if(pidx === -1){ showToast('Potion bag full'); return; }
+    potionBag[pidx] = it; lootMap.delete(key); showToast(`Picked up ${it.name}`);
+    redrawInventory();
+    return;
+  }
   const idx = bag.findIndex(b=>!b);
   if(idx === -1){ showToast('Bag full'); return; }
   bag[idx] = it; lootMap.delete(key); showToast(`Picked up ${it.name}`);
@@ -564,15 +572,16 @@ function pickupHere(){
 
 function equipFromBag(idx){
   const it = bag[idx]; if(!it) return;
-  if(it.type==='potion'){
-    usePotion(it);
-    bag[idx]=null;
-    redrawInventory();
-    return;
-  }
   const slot = it.slot; const prev = equip[slot];
   equip[slot] = it; bag[idx] = prev || null; showToast(`Equipped ${it.name}`);
   redrawInventory(); recalcStats();
+}
+
+function usePotionFromBag(idx){
+  const it = potionBag[idx]; if(!it) return;
+  usePotion(it);
+  potionBag[idx]=null;
+  redrawInventory();
 }
 
 function usePotion(it){
@@ -597,6 +606,10 @@ function dropFromBag(idx){ const it=bag[idx]; if(!it) return; lootMap.set(`${pla
 
 function sellFromBag(idx){ const it=bag[idx]; if(!it) return; const price=getSellPrice(it); player.gold+=price; hudGold.textContent=player.gold; showToast(`Sold ${it.name} for ${price}`); bag[idx]=null; redrawInventory(); }
 
+function dropFromPotionBag(idx){ const it=potionBag[idx]; if(!it) return; lootMap.set(`${player.x},${player.y}`,it); potionBag[idx]=null; showToast(`Dropped ${it.name}`); redrawInventory(); }
+
+function sellFromPotionBag(idx){ const it=potionBag[idx]; if(!it) return; const price=getSellPrice(it); player.gold+=price; hudGold.textContent=player.gold; showToast(`Sold ${it.name} for ${price}`); potionBag[idx]=null; redrawInventory(); }
+
 function unequipAndSell(slot){ const it=equip[slot]; if(!it) return; const price=getSellPrice(it); equip[slot]=null; player.gold+=price; hudGold.textContent=player.gold; showToast(`Sold ${it.name} for ${price}`); redrawInventory(); recalcStats(); }
 
 function redrawInventory(){
@@ -616,7 +629,13 @@ function redrawInventory(){
     html += `<div class="list-row" data-type="bag" data-idx="${i}"><div>${i+1}. ${it?`<span style="color:${it.color}">${escapeHtml(it.name)}</span>`:'(empty)'}</div><div class="muted">${it?shortMods(it):''}</div></div>`;
   }
   html += '<div class="hr"></div>';
-  html += '<div id="invDetails" class="muted">Hover an item to see details. Click bag item to Equip or Use. Click equipped item to Unequip. Use buttons below for Sell/Drop.</div>';
+  html += '<div class="section-title">Potions</div>';
+  for(let i=0;i<POTION_BAG_SIZE;i++){
+    const it = potionBag[i];
+    html += `<div class="list-row" data-type="pbag" data-idx="${i}"><div>${i+1}. ${it?`<span style="color:${it.color}">${escapeHtml(it.name)}</span>`:'(empty)'}</div><div class="muted">${it?shortMods(it):''}</div></div>`;
+  }
+  html += '<div class="hr"></div>';
+  html += '<div id="invDetails" class="muted">Hover an item to see details. Click bag item to Equip or Use. Click potion to Use. Click equipped item to Unequip. Use buttons below for Sell/Drop.</div>';
   html += '<div class="actions" style="margin-top:8px"><button id="btnSell" class="btn sml" disabled>Sell</button><button id="btnDrop" class="btn sml" disabled>Drop</button></div>';
   panel.innerHTML = html;
 
@@ -626,19 +645,21 @@ function redrawInventory(){
   };
   panel.onclick = (e)=>{
     const row = e.target.closest('.list-row'); if(row){
-      const t=row.dataset.type; if(t==='bag'){ equipFromBag(parseInt(row.dataset.idx,10)); } else if(t==='eq'){ unequip(row.dataset.slot); }
+      const t=row.dataset.type; if(t==='bag'){ equipFromBag(parseInt(row.dataset.idx,10)); } else if(t==='eq'){ unequip(row.dataset.slot); } else if(t==='pbag'){ usePotionFromBag(parseInt(row.dataset.idx,10)); }
     }
   };
   document.getElementById('btnSell').onclick = ()=>{
     const sel = document.getElementById('invDetails').dataset.sel;
     const kind = document.getElementById('invDetails').dataset.kind;
     if(kind==='bag'){ sellFromBag(parseInt(sel,10)); }
+    if(kind==='pbag'){ sellFromPotionBag(parseInt(sel,10)); }
     if(kind==='eq'){ unequipAndSell(sel); }
   };
   document.getElementById('btnDrop').onclick = ()=>{
     const sel = document.getElementById('invDetails').dataset.sel;
     const kind = document.getElementById('invDetails').dataset.kind;
     if(kind==='bag'){ dropFromBag(parseInt(sel,10)); }
+    if(kind==='pbag'){ dropFromPotionBag(parseInt(sel,10)); }
   };
 }
 
@@ -649,6 +670,11 @@ function showItemDetailsFromRow(row){
   if(t==='bag'){
     const i=parseInt(row.dataset.idx,10); const it=bag[i]; if(!it){ setDetailsText('(empty slot)'); disableInvActions(); return; }
     det.dataset.sel=String(i); det.dataset.kind='bag';
+    setDetailsText(renderDetails(it, 'bag'));
+    document.getElementById('btnSell').disabled=false; document.getElementById('btnDrop').disabled=false;
+  }else if(t==='pbag'){
+    const i=parseInt(row.dataset.idx,10); const it=potionBag[i]; if(!it){ setDetailsText('(empty slot)'); disableInvActions(); return; }
+    det.dataset.sel=String(i); det.dataset.kind='pbag';
     setDetailsText(renderDetails(it, 'bag'));
     document.getElementById('btnSell').disabled=false; document.getElementById('btnDrop').disabled=false;
   }else if(t==='eq'){
@@ -809,6 +835,11 @@ function renderShop(){
 function buyItem(idx){
   const it=shopStock[idx]; if(!it) return;
   if(player.gold<it.price){ showToast('Not enough gold'); return; }
+  if(it.type==='potion'){
+    const slot=potionBag.findIndex(b=>!b); if(slot===-1){ showToast('Potion bag full'); return; }
+    player.gold-=it.price; hudGold.textContent=player.gold; potionBag[slot]=stripShopFields(it); showToast(`Bought ${it.name}`); shopStock.splice(idx,1); renderShop(); redrawInventory();
+    return;
+  }
   const slot=bag.findIndex(b=>!b); if(slot===-1){ showToast('Bag full'); return; }
   player.gold-=it.price; hudGold.textContent=player.gold; bag[slot]=stripShopFields(it); showToast(`Bought ${it.name}`); shopStock.splice(idx,1); renderShop(); redrawInventory();
 }
@@ -1298,13 +1329,13 @@ const keys={};
 window.addEventListener('keydown',e=>{
   keys[e.key]=true;
   if(e.key==='i'||e.key==='I') toggleInv();
-  // quick-use potions from bag slots with number keys 1-3
+  // quick-use potions from potion bag slots with number keys 1-3
   if(e.key==='1'||e.key==='2'||e.key==='3'){
     const idx = parseInt(e.key,10)-1;
-    const it = bag[idx];
-    if(it && it.type==='potion'){
+    const it = potionBag[idx];
+    if(it){
       usePotion(it);
-      bag[idx]=null;
+      potionBag[idx]=null;
       const panel=document.getElementById('inventory');
       if(panel && panel.style.display==='block') redrawInventory();
     }


### PR DESCRIPTION
## Summary
- Separate potion storage from general bag
- Support quick-use and merchant interactions for potion bag
- Document potion bag hotkeys

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1f4e43188322a98913e283782255