### PR TITLE
Add simple audio effects for footsteps and combat

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,6 +339,61 @@ const hpLbl=document.getElementById('hpLbl'); const mpLbl=document.getElementByI
 const hudFloor=document.getElementById('hudFloor'); const hudSeed=document.getElementById('hudSeed'); const hudGold=document.getElementById('hudGold'); const hudDmg=document.getElementById('hudDmg');
 const xpFill=document.getElementById('xpFill'); const xpLbl=document.getElementById('xpLbl'); const hudLvl=document.getElementById('hudLvl');
 
+// ===== Audio =====
+let audioCtx, musicTimer;
+function initAudio(){
+  if(!audioCtx) audioCtx = new (window.AudioContext||window.webkitAudioContext)();
+  if(audioCtx.state === 'suspended') audioCtx.resume();
+}
+function playFootstep(){
+  initAudio(); if(!audioCtx) return;
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(120 + Math.random()*30, audioCtx.currentTime);
+  gain.gain.setValueAtTime(0.001, audioCtx.currentTime);
+  gain.gain.linearRampToValueAtTime(0.15, audioCtx.currentTime + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.25);
+  osc.connect(gain).connect(audioCtx.destination);
+  osc.start(); osc.stop(audioCtx.currentTime + 0.25);
+}
+function playAttack(){
+  initAudio(); if(!audioCtx) return;
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.type = 'sawtooth';
+  osc.frequency.setValueAtTime(300, audioCtx.currentTime);
+  gain.gain.setValueAtTime(0.2, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.15);
+  osc.connect(gain).connect(audioCtx.destination);
+  osc.start(); osc.stop(audioCtx.currentTime + 0.15);
+}
+function playHit(){
+  initAudio(); if(!audioCtx) return;
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.type = 'triangle';
+  osc.frequency.setValueAtTime(180, audioCtx.currentTime);
+  gain.gain.setValueAtTime(0.25, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.2);
+  osc.connect(gain).connect(audioCtx.destination);
+  osc.start(); osc.stop(audioCtx.currentTime + 0.2);
+}
+function startMusic(){
+  initAudio(); if(startMusic.started) return; startMusic.started = true;
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  gain.gain.value = 0.04;
+  osc.type = 'sine';
+  osc.connect(gain).connect(audioCtx.destination);
+  const notes = [130.81,146.83,155.56,174.61,196,207.65,233.08]; // A minor
+  let i = 0;
+  function next(){ osc.frequency.setValueAtTime(notes[i % notes.length], audioCtx.currentTime); i++; }
+  next();
+  musicTimer = setInterval(next, 2000);
+  osc.start();
+}
+
 // --- Smooth helpers & settings ---
 function smoothstep01(t){ return t*t*(3-2*t); }
 function lerp(a,b,t){ return a + (b-a)*t; }
@@ -853,7 +908,7 @@ function toggleShop(show){ const el=document.getElementById('shop'); el.style.di
 function dealDamageToMonster(m, base, elem=null, crit=false){
   const vuln = getEffectPower(m,'shock') || 0;
   const dmg = Math.max(1, Math.floor(base * (1 + vuln)));
-  m.hp -= dmg; m.hitFlash = 4;
+  m.hp -= dmg; m.hitFlash = 4; playHit();
   const col = elem==='fire' ? '#ff6b4a' : elem==='ice' ? '#7dd3fc' : elem==='shock' ? '#facc15' : (crit?'#ffe066':'#ffd24a');
   addDamageText(m.x,m.y,`-${dmg}`, col);
 }
@@ -959,6 +1014,7 @@ function applyDamageToPlayer(dmg, type='physical'){
 
   player.hp = Math.max(0, player.hp - eff);
   damageTexts.push({ tx:player.x, ty:player.y, text:`-${eff}`, color:(type==='magic'?'#b84aff':'#ff6b6b'), age:0, ttl:900 });
+  playHit();
   if(player.hp===0){ showRespawn(); }
 }
 
@@ -990,7 +1046,7 @@ function performPlayerAttack(dx,dy){
   if(player.atkCD>0) return;
   dx = Math.max(-1, Math.min(1, dx|0)); dy = Math.max(-1, Math.min(1, dy|0));
   if(dx===0 && dy===0) return;
-  player.faceDx = dx; player.faceDy = dy;
+  player.faceDx = dx; player.faceDy = dy; playAttack();
   const prof = currentWeaponProfile();
   const {min,max,crit,ls} = currentAtk();
   let dmg=rng.int(min,max); const wasCrit=(Math.random()*100<crit); if(wasCrit) dmg=Math.floor(dmg*1.5); dmg=Math.max(1,dmg);
@@ -1331,7 +1387,7 @@ function update(dt){
           const gearFactor = (1 - Math.min(0.5, player.speedPct/100));
           const freezeMul = speedMultFromEffects(player);
           const dur = Math.max(60, baseStepDelay * gearFactor * diag * freezeMul);
-          player.moveDur = dur; player.stepCD = dur;
+          player.moveDur = dur; player.stepCD = dur; playFootstep();
           if(smoothEnabled){ player.fromX=player.rx; player.fromY=player.ry; player.toX=player.x; player.toY=player.y; player.moveT=0; player.moving=true; }
           else{ player.rx=player.x; player.ry=player.y; player.moving=false; player.moveT=1; }
         }
@@ -1486,6 +1542,7 @@ function loop(now){ const dt = Math.min(50, now - __last); __last = now; update(
 
 // ===== Start =====
 function startGame(){
+  initAudio(); startMusic();
   // gender pick -> sprite
   const gSel = document.querySelector('input[name="gender"]:checked');
   player.gender = (gSel?.value==='f')?'f':'m';


### PR DESCRIPTION
## Summary
- add Web Audio helpers for footsteps, attacks, hits, and ambient music
- play step sound on movement and combat sounds on attacks/damage
- start low-volume background music when game begins

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad25b1f778832285914f9a343da727