### PR TITLE
Add warrior and mage class options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Random weapon name generator for unique gear titles.
 - Weapon damage-over-time affix that can ignite foes.
 - Melee weapon classes now inflict bleed damage over time.
+- Playable Warrior and Mage classes with distinct health, mana, and attack bonuses.
 
 - Consumable potions appear in loot and shop inventories.
 - Legendary rarity added for gear and weapon drops.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 2D Dungeon Game
 
-An offline single-file HTML5 dungeon crawler with inline sprites, now featuring consumable potions and legendary gear.
+An offline single-file HTML5 dungeon crawler with inline sprites, now featuring consumable potions, legendary gear, and class-based heroes.
 
 ## Play the Game
 Open `index.html` in your browser.  
@@ -18,6 +18,10 @@ Then visit [http://localhost:8000](http://localhost:8000).
 - **E** – Use stairs or the merchant
 - **1/2/3** – Quick-use potion from potion bag slot 1–3
 - **Click monsters** – Attack
+
+## Classes
+- **Warrior** – high health and attack, low mana
+- **Mage** – high mana and spell damage
 
 ## Development Notes
 - The project is contained in a single HTML file (`index.html`) with inline JavaScript and no build step.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-<title>Dungeon — Sprites + Gender + Shop/Stairs (Single-file)</title>
+<title>Dungeon — Sprites + Classes + Shop/Stairs (Single-file)</title>
 <style>
   html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,Roboto,Ubuntu,Arial,sans-serif;overflow:hidden}
   #ui{position:fixed;inset:0;display:grid;grid-template-rows:auto 1fr auto;pointer-events:none}
@@ -40,10 +40,10 @@
   .item-title{font-weight:600}
   .green{color:#76d38b}
   .red{color:#ff6b6b}
-  .gender-card{display:flex;align-items:center;gap:10px;padding:8px;border:1px solid #2a2d39;border-radius:10px;cursor:pointer}
-  .gender-card:hover{background:#12141f}
-  .gender-card input{accent-color:#7a4bd9}
-  .gender-preview{width:32px;height:32px;border-radius:6px;background:#0f1119;display:grid;place-items:center}
+  .class-card{display:flex;align-items:center;gap:10px;padding:8px;border:1px solid #2a2d39;border-radius:10px;cursor:pointer}
+  .class-card:hover{background:#12141f}
+  .class-card input{accent-color:#7a4bd9}
+  .class-preview{width:32px;height:32px;border-radius:6px;background:#0f1119;display:grid;place-items:center}
 </style>
 </head>
 <body>
@@ -100,22 +100,22 @@
       </ul>
     </div>
 
-    <div class="section-title" style="margin-top:10px">Choose your character</div>
+    <div class="section-title" style="margin-top:10px">Choose your class</div>
     <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;pointer-events:auto">
-      <label class="gender-card">
-        <input type="radio" name="gender" value="m" checked>
-        <div class="gender-preview"><img id="prevMale" alt="male" /></div>
+      <label class="class-card">
+        <input type="radio" name="class" value="warrior" checked>
+        <div class="class-preview"><img id="prevWarrior" alt="warrior" /></div>
         <div>
-          <div><b>Male</b></div>
-          <div class="muted" style="font-size:12px">Balanced adventurer</div>
+          <div><b>Warrior</b></div>
+          <div class="muted" style="font-size:12px">Sturdy fighter: high health and damage, low mana</div>
         </div>
       </label>
-      <label class="gender-card">
-        <input type="radio" name="gender" value="f">
-        <div class="gender-preview"><img id="prevFemale" alt="female" /></div>
+      <label class="class-card">
+        <input type="radio" name="class" value="mage">
+        <div class="class-preview"><img id="prevMage" alt="mage" /></div>
         <div>
-          <div><b>Female</b></div>
-          <div class="muted" style="font-size:12px">Swift adventurer</div>
+          <div><b>Mage</b></div>
+          <div class="muted" style="font-size:12px">Arcane caster: high mana and spell damage</div>
         </div>
       </label>
     </div>
@@ -213,8 +213,8 @@ function makeSprite(size, draw){ const c=document.createElement('canvas'); c.wid
 function px(g,x,y,w,h,col){ g.fillStyle=col; g.fillRect(x,y,w,h); }
 function outline(g,size){ g.globalCompositeOperation='destination-over'; g.strokeStyle='rgba(0,0,0,0.6)'; g.lineWidth=1; g.strokeRect(0.5,0.5,size-1,size-1); g.globalCompositeOperation='source-over'; }
 function genSprites(){
-  // Player male 24x24
-  SPRITES.player_m = makeSprite(24,(g,S)=>{
+  // Warrior 24x24
+  SPRITES.player_warrior = makeSprite(24,(g,S)=>{
     // boots & pants
     px(g,5,18,14,3,'#2b2f3a'); px(g,6,16,12,3,'#3a4060');
     // tunic
@@ -228,8 +228,8 @@ function genSprites(){
     outline(g,S);
   });
 
-  // Player female 24x24
-  SPRITES.player_f = makeSprite(24,(g,S)=>{
+  // Mage 24x24
+  SPRITES.player_mage = makeSprite(24,(g,S)=>{
     // boots & leggings
     px(g,5,18,14,3,'#303446'); px(g,6,16,12,3,'#c65f92');
     // dress/armor
@@ -320,8 +320,8 @@ function genSprites(){
   SPRITES.merchant_tile = makeSprite(24,(g,S)=>{ px(g,4,4,16,16,'#8a5cff'); outline(g,S); });
 
   // previews on start screen
-  const prevMale=document.getElementById('prevMale'); const prevFemale=document.getElementById('prevFemale');
-  if(prevMale) prevMale.src = SPRITES.player_m.url; if(prevFemale) prevFemale.src = SPRITES.player_f.url;
+  const prevWar=document.getElementById('prevWarrior'); const prevMage=document.getElementById('prevMage');
+  if(prevWar) prevWar.src = SPRITES.player_warrior.url; if(prevMage) prevMage.src = SPRITES.player_mage.url;
 }
 
 // generate immediately so previews show on start
@@ -330,8 +330,54 @@ genSprites();
 let seed=(Math.random()*1e9)|0, floorNum=1, rng=new RNG(seed);
 let map=[], fog=[], vis=[]; let rooms=[]; let stairs={x:0,y:0};
 let merchant={x:0,y:0}; let merchantStyle = Math.random()<0.5 ? 'goblin' : 'stall';
-let player={x:0,y:0,hp:150,hpMax:150,mp:60,mpMax:60,gold:0,stepCD:0,stepDelay:140,speedPct:0,lvl:1,xp:0,xpToNext:50,baseAtkBonus:0, gender:'m', atkCD:0, faceDx:1, faceDy:0, effects:[]};
-let playerSpriteKey = 'player_m';
+// Player state and default class (Warrior)
+const player={
+  x:0, y:0,
+  hp:180, hpMax:180,
+  mp:40, mpMax:40,
+  gold:0,
+  stepCD:0, stepDelay:140, speedPct:0,
+  lvl:1, xp:0, xpToNext:50,
+  baseAtkBonus:0, baseSpellBonus:0,
+  class:'warrior',
+  atkCD:0, faceDx:1, faceDy:0,
+  effects:[],
+  hpBase:180, mpBase:40,
+  magicPoints:0,
+  magic:{
+    healing:[false,false,false,false],
+    damage:[false,false,false,false],
+    dot:[false,false,false,false]
+  },
+  boundSpell:null
+};
+let playerSpriteKey = 'player_warrior'; // updated on class selection
+// Base stats per class
+const CLASS_BASES={
+  warrior:{hp:180, mp:40, atk:2, spell:0},
+  mage:{hp:150, mp:100, atk:0, spell:3}
+};
+// Spell trees for the magic system
+const magicTrees={
+  healing:{display:'Healing',abilities:[
+    {name:'Heal I',type:'heal',value:30,mp:10,cost:1},
+    {name:'Heal II',type:'heal',value:60,mp:20,cost:1},
+    {name:'Heal III',type:'heal',value:120,mp:30,cost:1},
+    {name:'Heal IV',type:'heal',value:null,mp:40,cost:1}
+  ]},
+  damage:{display:'Damage',abilities:[
+    {name:'Fire Bolt',type:'damage',dmg:25,mp:10,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2000,power:1.0,chance:1}},
+    {name:'Ice Spike',type:'damage',dmg:35,mp:15,cost:1,range:8,elem:'ice',status:{k:'freeze',dur:1800,power:0.4,chance:1}},
+    {name:'Lightning Bolt',type:'damage',dmg:50,mp:20,cost:1,range:9,elem:'shock',status:{k:'shock',dur:2000,power:0.25,chance:1}},
+    {name:'Arcane Blast',type:'damage',dmg:70,mp:30,cost:1,range:9,elem:'magic'}
+  ]},
+  dot:{display:'Damage Over Time',abilities:[
+    {name:'Ignite',type:'dot',dmg:10,mp:12,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2200,power:1.0,chance:1}},
+    {name:'Scorch',type:'dot',dmg:15,mp:16,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2600,power:1.1,chance:1}},
+    {name:'Sear',type:'dot',dmg:20,mp:20,cost:1,range:8,elem:'fire',status:{k:'burn',dur:3000,power:1.2,chance:1}},
+    {name:'Inferno',type:'dot',dmg:25,mp:25,cost:1,range:8,elem:'fire',status:{k:'burn',dur:3400,power:1.3,chance:1}}
+  ]}
+};
 // Monsters now have richer AI with per-type patterns and scaling
 // {x,y,rx,ry,type,hp,hpMax,dmgMin,dmgMax,atkCD,moveCD,state:{...},hitFlash,effects:[]}
 let monsters=[];
@@ -1047,7 +1093,7 @@ canvas.addEventListener('mousedown', (e)=>{
 function currentAtk(){
   // why: single source-of-truth for attack numbers (incl. level & gear)
   let min=2,max=4,crit=5,ls=0;
-  const lvlBonus = Math.floor((player.lvl-1)*0.6); min+=lvlBonus; max+=lvlBonus;
+  const lvlBonus = Math.floor((player.lvl-1)*0.6) + (player.baseAtkBonus||0); min+=lvlBonus; max+=lvlBonus;
   const w=equip.weapon?.mods||{}; min+=w.dmgMin||0; max+=w.dmgMax||0; crit += w.crit||0; ls=w.ls||0; return {min,max,crit,ls};
 }
 
@@ -1106,7 +1152,7 @@ function performPlayerAttack(dx,dy){
   player.faceDx = dx; player.faceDy = dy; playAttack();
   const prof = currentWeaponProfile();
   const {min,max,crit,ls} = currentAtk();
-  let dmg=rng.int(min,max); const wasCrit=(Math.random()*100<crit); if(wasCrit) dmg=Math.floor(dmg*1.5); dmg=Math.max(1,dmg);
+  let dmg=rng.int(min,max); if(prof.dtype==='magic') dmg += (player.baseSpellBonus||0); const wasCrit=(Math.random()*100<crit); if(wasCrit) dmg=Math.floor(dmg*1.5); dmg=Math.max(1,dmg);
   const wStatus = equip.weapon?.mods?.status || null;
   const atkStatus = wStatus || prof.status || null;
   if(prof.kind==='melee'){
@@ -1574,6 +1620,7 @@ function loadGame(){
   seed=data.seed; rng=new RNG(seed); floorNum=data.floorNum;
   generate();
   Object.assign(player, data.player||{});
+  playerSpriteKey = player.class==='mage' ? 'player_mage' : 'player_warrior';
   bag=data.bag||new Array(BAG_SIZE).fill(null);
   potionBag=data.potionBag||new Array(POTION_BAG_SIZE).fill(null);
   equip=data.equip||{helmet:null,chest:null,legs:null,hands:null,feet:null,weapon:null};
@@ -1617,8 +1664,8 @@ function showRespawn(){ gameOver=true; const d=document.getElementById('respawn'
 function recalcStats(){
   let dmgMin=2,dmgMax=4,crit=5,armor=0;
   const hpGainPerLevel = 12, mpGainPerLevel = 6;
-  let hpMax = 150 + (player.lvl-1)*hpGainPerLevel;
-  let mpMax = 60 + (player.lvl-1)*mpGainPerLevel;
+  let hpMax = (player.hpBase||150) + (player.lvl-1)*hpGainPerLevel;
+  let mpMax = (player.mpBase||60) + (player.lvl-1)*mpGainPerLevel;
   let speedPct=0;
   let resF=0,resI=0,resS=0,resM=0;
   // level bonus
@@ -1645,10 +1692,17 @@ function loop(now){ const dt = Math.min(50, now - __last); __last = now; update(
 // ===== Start =====
 function startGame(){
   initAudio(); startMusic();
-  // gender pick -> sprite
-  const gSel = document.querySelector('input[name="gender"]:checked');
-  player.gender = (gSel?.value==='f')?'f':'m';
-  playerSpriteKey = player.gender==='f' ? 'player_f' : 'player_m';
+  // class pick -> sprite and stats
+  const cSel = document.querySelector('input[name="class"]:checked');
+  player.class = (cSel?.value==='mage')?'mage':'warrior';
+  const base = CLASS_BASES[player.class];
+  player.hpBase = base.hp;
+  player.mpBase = base.mp;
+  player.baseAtkBonus = base.atk;
+  player.baseSpellBonus = base.spell;
+  player.hp=player.hpMax=player.hpBase;
+  player.mp=player.mpMax=player.mpBase;
+  playerSpriteKey = player.class==='mage' ? 'player_mage' : 'player_warrior';
 
   hudFloor.textContent=floorNum; hudSeed.textContent=seed>>>0; hudGold.textContent=player.gold; hudLvl.textContent=player.lvl;
   generate(); recalcStats(); recomputeFOV();


### PR DESCRIPTION
## Summary
- Allow choosing Warrior or Mage classes at game start
- Apply class-specific stat presets for health, mana, and attack bonuses
- Align default warrior base stats with class presets
- Document class system in README and changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad32d6acbc8322b4307f47e7b75eea