### PR TITLE
feat: expand magic trees with tiered unlock costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 ### Added
 - Warrior and Mage player classes with unique stat bonuses.
 - Player magic system with three ability trees and Q-bound spells.
+- Additional spells added to each magic tree.
 - Random weapon name generator for unique gear titles.
 - Weapon damage-over-time affix that can ignite foes.
 - Melee weapon classes now inflict bleed damage over time.
@@ -18,6 +19,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 ### Changed
 - Increased player starting health by 50 points.
 - Reduced base health of all monster types.
+- Magic abilities now require sequential unlocking with escalating point costs.
 - Reworked weapon and armor attributes for improved random bonuses.
 - Reduced monster density on early floors.
 - Increased XP reward per monster by 25%.

--- a/index.html
+++ b/index.html
@@ -352,26 +352,32 @@ genSprites();
 let seed=(Math.random()*1e9)|0, floorNum=1, rng=new RNG(seed);
 let map=[], fog=[], vis=[]; let rooms=[]; let stairs={x:0,y:0};
 let merchant={x:0,y:0}; let merchantStyle = Math.random()<0.5 ? 'goblin' : 'stall';
-let player={x:0,y:0,hp:150,hpMax:150,mp:60,mpMax:60,gold:0,stepCD:0,stepDelay:140,speedPct:0,lvl:1,xp:0,xpToNext:50,baseAtkBonus:0, gender:'m', class:'warrior', atkCD:0, faceDx:1, faceDy:0, effects:[], magicPoints:0, magic:{healing:[false,false,false,false],damage:[false,false,false,false],dot:[false,false,false,false]}, boundSpell:null};
+let player={x:0,y:0,hp:150,hpMax:150,mp:60,mpMax:60,gold:0,stepCD:0,stepDelay:140,speedPct:0,lvl:1,xp:0,xpToNext:50,baseAtkBonus:0, gender:'m', class:'warrior', atkCD:0, faceDx:1, faceDy:0, effects:[], magicPoints:0, magic:{healing:[false,false,false,false,false,false],damage:[false,false,false,false,false,false],dot:[false,false,false,false,false,false]}, boundSpell:null};
 let playerSpriteKey = 'player_m';
 const magicTrees={
   healing:{display:'Healing',abilities:[
     {name:'Heal I',type:'heal',value:30,mp:10,cost:1},
-    {name:'Heal II',type:'heal',value:60,mp:20,cost:1},
-    {name:'Heal III',type:'heal',value:120,mp:30,cost:1},
-    {name:'Heal IV',type:'heal',value:null,mp:40,cost:1}
+    {name:'Heal II',type:'heal',value:60,mp:20,cost:2},
+    {name:'Heal III',type:'heal',value:120,mp:30,cost:3},
+    {name:'Heal IV',type:'heal',value:null,mp:40,cost:4},
+    {name:'Heal V',type:'heal',value:null,mp:60,cost:5},
+    {name:'Divine Light',type:'heal',value:null,mp:80,cost:9}
   ]},
   damage:{display:'Damage',abilities:[
     {name:'Fire Bolt',type:'damage',dmg:25,mp:10,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2000,power:1.0,chance:1}},
-    {name:'Ice Spike',type:'damage',dmg:35,mp:15,cost:1,range:8,elem:'ice',status:{k:'freeze',dur:1800,power:0.4,chance:1}},
-    {name:'Lightning Bolt',type:'damage',dmg:50,mp:20,cost:1,range:9,elem:'shock',status:{k:'shock',dur:2000,power:0.25,chance:1}},
-    {name:'Arcane Blast',type:'damage',dmg:70,mp:30,cost:1,range:9,elem:'magic'}
+    {name:'Ice Spike',type:'damage',dmg:35,mp:15,cost:2,range:8,elem:'ice',status:{k:'freeze',dur:1800,power:0.4,chance:1}},
+    {name:'Lightning Bolt',type:'damage',dmg:50,mp:20,cost:3,range:9,elem:'shock',status:{k:'shock',dur:2000,power:0.25,chance:1}},
+    {name:'Arcane Blast',type:'damage',dmg:70,mp:30,cost:4,range:9,elem:'magic'},
+    {name:'Meteor',type:'damage',dmg:90,mp:40,cost:5,range:9,elem:'fire',status:{k:'burn',dur:3000,power:1.5,chance:1}},
+    {name:'Void Ray',type:'damage',dmg:130,mp:60,cost:9,range:10,elem:'magic'}
   ]},
   dot:{display:'Damage Over Time',abilities:[
     {name:'Ignite',type:'dot',dmg:10,mp:12,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2200,power:1.0,chance:1}},
-    {name:'Scorch',type:'dot',dmg:15,mp:16,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2600,power:1.1,chance:1}},
-    {name:'Sear',type:'dot',dmg:20,mp:20,cost:1,range:8,elem:'fire',status:{k:'burn',dur:3000,power:1.2,chance:1}},
-    {name:'Inferno',type:'dot',dmg:25,mp:25,cost:1,range:8,elem:'fire',status:{k:'burn',dur:3400,power:1.3,chance:1}}
+    {name:'Scorch',type:'dot',dmg:15,mp:16,cost:2,range:8,elem:'fire',status:{k:'burn',dur:2600,power:1.1,chance:1}},
+    {name:'Sear',type:'dot',dmg:20,mp:20,cost:3,range:8,elem:'fire',status:{k:'burn',dur:3000,power:1.2,chance:1}},
+    {name:'Inferno',type:'dot',dmg:25,mp:25,cost:4,range:8,elem:'fire',status:{k:'burn',dur:3400,power:1.3,chance:1}},
+    {name:'Conflagrate',type:'dot',dmg:30,mp:28,cost:5,range:8,elem:'fire',status:{k:'burn',dur:3800,power:1.4,chance:1}},
+    {name:'Hellfire',type:'dot',dmg:40,mp:35,cost:9,range:8,elem:'fire',status:{k:'burn',dur:4200,power:1.5,chance:1}}
   ]}
 };
 // Monsters now have richer AI with per-type patterns and scaling
@@ -1614,7 +1620,8 @@ function redrawMagic(){
       if(unlocked){
         html += `<div class="list-row"><div>${ab.name}</div><div>${bind?'<span class="green">Bound</span>':`<button class="btn sml" data-bind="${treeName}-${i}">Bind</button>`}</div></div>`;
       }else{
-        const dis = player.magicPoints<ab.cost?'disabled':'';
+        const prevUnlocked = i===0 || player.magic[treeName][i-1];
+        const dis = (player.magicPoints<ab.cost || !prevUnlocked)?'disabled':'';
         html += `<div class="list-row"><div>${ab.name}</div><div><button class="btn sml" data-unlock="${treeName}-${i}" ${dis}>Unlock (${ab.cost})</button></div></div>`;
       }
     });
@@ -1637,6 +1644,7 @@ function toggleMagic(){ let panel=document.getElementById('magic'); if(!panel){ 
 function unlockSpell(treeName, idx){
   const ab=magicTrees[treeName].abilities[idx];
   if(player.magic[treeName][idx]) return;
+  if(idx>0 && !player.magic[treeName][idx-1]){ showToast('Unlock previous ability first'); return; }
   if(player.magicPoints>=ab.cost){ player.magicPoints-=ab.cost; player.magic[treeName][idx]=true; showToast(`Unlocked ${ab.name}`); }
   else showToast('Not enough points');
 }
@@ -1687,6 +1695,10 @@ function loadGame(){
   generate();
   Object.assign(player, data.player||{});
   if(!player.class) player.class = 'warrior';
+  for(const t of ['healing','damage','dot']){
+    player.magic[t] = player.magic[t] || [];
+    while(player.magic[t].length < magicTrees[t].abilities.length) player.magic[t].push(false);
+  }
   bag=data.bag||new Array(BAG_SIZE).fill(null);
   potionBag=data.potionBag||new Array(POTION_BAG_SIZE).fill(null);
   equip=data.equip||{helmet:null,chest:null,legs:null,hands:null,feet:null,weapon:null};


### PR DESCRIPTION
## Summary
- add two new spells to each magic tree
- increase point costs so top-tier spells require significant investment
- require sequential unlocking of magic abilities and update saved games

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3fe38c008322b97f3e9261114272