### PR TITLE
feat: refine experimental ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Reduced wizard spawn chance on lower floors.
 - Increased potion drop rate to 40% (from 25%).
 - Mage enemies now fire 30% slower but hit 10% harder.
+- Refined Experimental_UI with a new themed stylesheet and panel design.
 
 ## 2025-08-26
 ### Added

--- a/Experimental_UI/index.html
+++ b/Experimental_UI/index.html
@@ -5,47 +5,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1.0" />
 <title>Dungeon — Sprites + Gender + Shop/Stairs (Single-file)</title>
-<style>
-  html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,Roboto,Ubuntu,Arial,sans-serif;overflow:hidden}
-  #ui{position:fixed;inset:0;display:grid;grid-template-rows:auto 1fr auto;pointer-events:none}
-  .topbar{display:flex;gap:16px;align-items:center;padding:8px 14px;background:linear-gradient(#191a1f,#111219);border-bottom:1px solid #2a2d39;transform:scale(1.2);transform-origin:top left;width:calc(100%/1.2)}
-  .panel{background:rgba(15,16,22,0.9);border:1px solid #2a2d39;border-radius:10px;box-shadow:0 0 0 1px rgba(255,255,255,0.03) inset}
-  .stat{height:14px;width:220px; background:#222;border:1px solid #333;border-radius:6px;position:relative}
-  .fill{position:absolute;left:0;top:0;height:100%;background:#3c7}
-  .fill.hp{background:#d44}
-  .fill.mp{background:#47c}
-  .fill.xp{background:#7a4bd9}
-  .label{position:absolute;left:0;right:0;top:-18px;font-size:12px;opacity:.85;text-align:center}
-  .hud-kv{font-size:13px;opacity:.9}
-  #gameCanvas{position:fixed;left:0;top:0}
-  .btn{display:inline-block;padding:8px 14px;border:1px solid #3a3e4d;border-radius:8px;background:#141622;color:#e6e6f0;cursor:pointer}
-  .btn:hover{background:#1a1d2a}
-  .stone{background-image:linear-gradient(180deg,rgba(255,255,255,.03),rgba(0,0,0,.08));}
-  .footer{padding:6px 12px;border-top:1px solid #2a2d39;background:linear-gradient(#0f1016,#0b0c11);opacity:.85}
-  #inventory{display:none;position:fixed;right:8px;top:64px;padding:8px 12px;pointer-events:auto;font-size:13px;width:600px;max-width:90vw}
-  #shop{display:none;position:fixed;left:8px;top:64px;min-width:320px;padding:10px 12px;pointer-events:auto;font-size:13px}
-  #magic{display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);padding:8px 12px;pointer-events:auto;font-size:13px;width:340px;max-width:90vw;max-height:70vh;overflow:auto}
-  .list-row{display:flex;justify-content:space-between;gap:8px;padding:6px 6px;border-radius:6px}
-  .inv-grid{display:grid;grid-template-columns:repeat(6,1fr);gap:4px 8px}
-  .inv-grid .list-row{flex-direction:column;gap:2px}
-  .list-row:hover{background:#1a1d28}
-  .muted{opacity:.75}
-  .kv{display:flex;gap:6px;align-items:center}
-  .mono{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace}
-  .pill{display:inline-block;padding:1px 6px;border:1px solid #2d3140;border-radius:999px;background:#10131c}
-  .hr{height:1px;background:#2a2d39;margin:8px -8px}
-  .hint{opacity:.8}
-  .actions{display:flex;gap:8px;flex-wrap:wrap}
-  .sml{padding:6px 8px;font-size:12px;border-radius:6px}
-  .section-title{font-weight:bold;margin:6px 0 4px}
-  .item-title{font-weight:600}
-  .green{color:#76d38b}
-  .red{color:#ff6b6b}
-  .gender-card{display:flex;align-items:center;gap:10px;padding:8px;border:1px solid #2a2d39;border-radius:10px;cursor:pointer}
-  .gender-card:hover{background:#12141f}
-  .gender-card input{accent-color:#7a4bd9}
-  .gender-preview{width:32px;height:32px;border-radius:6px;background:#0f1119;display:grid;place-items:center}
-</style>
+<link rel="stylesheet" href="ui.css">
 </head>
 <body>
 <canvas id="gameCanvas"></canvas>

--- a/Experimental_UI/ui.css
+++ b/Experimental_UI/ui.css
@@ -1,0 +1,183 @@
+/* Refined experimental UI theme */
+:root{
+  --bg:#0b0b0e;
+  --panel-bg:#1d2640;
+  --panel-border:#77aaff;
+  --panel-radius:10px;
+  --text:#f1f5ff;
+  --text-muted:#a0b7d3;
+  --accent:#ffd24d;
+}
+
+html,body{
+  margin:0;
+  background:var(--bg);
+  color:var(--text);
+  font-family:'Segoe UI',Roboto,Ubuntu,Arial,sans-serif;
+  overflow:hidden;
+}
+
+#ui{position:fixed;inset:0;display:grid;grid-template-rows:auto 1fr auto;pointer-events:none}
+
+.topbar{
+  display:flex;
+  gap:16px;
+  align-items:center;
+  padding:8px 14px;
+  background:linear-gradient(#1b2338,#121829);
+  border-bottom:2px solid var(--panel-border);
+  box-shadow:0 2px 0 #0b0f19;
+}
+
+.panel{
+  background:var(--panel-bg);
+  border:2px solid var(--panel-border);
+  border-radius:var(--panel-radius);
+  box-shadow:0 2px 0 #142033;
+}
+
+.stat{
+  height:14px;
+  width:220px;
+  background:#0e1628;
+  border:2px solid var(--panel-border);
+  border-radius:6px;
+  position:relative;
+}
+
+.fill{position:absolute;left:0;top:0;height:100%}
+.fill.hp{background:#d24e4e}
+.fill.mp{background:#4e6bd2}
+.fill.xp{background:#8e6ddf}
+
+.label{position:absolute;left:0;right:0;top:-18px;font-size:12px;opacity:.85;text-align:center}
+
+.hud-kv{font-size:13px;opacity:.9}
+
+#gameCanvas{position:fixed;left:0;top:0}
+
+.btn{
+  display:inline-block;
+  padding:8px 14px;
+  border:2px solid var(--panel-border);
+  border-radius:8px;
+  background:var(--panel-bg);
+  color:var(--text);
+  cursor:pointer;
+  transition:background .15s;
+}
+.btn:hover{background:#25304e}
+
+.stone{background-image:linear-gradient(180deg,rgba(255,255,255,.03),rgba(0,0,0,.08));}
+
+.footer{
+  padding:6px 12px;
+  border-top:2px solid var(--panel-border);
+  background:linear-gradient(#1b2338,#121829);
+  opacity:.85;
+}
+
+#inventory{
+  display:none;
+  position:fixed;
+  right:8px;
+  top:64px;
+  padding:12px;
+  pointer-events:auto;
+  font-size:13px;
+  width:600px;
+  max-width:90vw;
+}
+
+#shop{
+  display:none;
+  position:fixed;
+  left:8px;
+  top:64px;
+  min-width:320px;
+  padding:12px;
+  pointer-events:auto;
+  font-size:13px;
+}
+
+#magic{
+  display:none;
+  position:fixed;
+  top:50%;
+  left:50%;
+  transform:translate(-50%,-50%);
+  padding:12px;
+  pointer-events:auto;
+  font-size:13px;
+  width:340px;
+  max-width:90vw;
+  max-height:70vh;
+  overflow:auto;
+}
+
+.list-row{
+  display:flex;
+  justify-content:space-between;
+  gap:8px;
+  padding:6px;
+  border-radius:6px;
+}
+
+.inv-grid{
+  display:grid;
+  grid-template-columns:repeat(6,1fr);
+  gap:4px 8px;
+}
+.inv-grid .list-row{flex-direction:column;gap:2px}
+
+.list-row:hover{background:#25304e}
+
+.muted{opacity:.75;color:var(--text-muted)}
+
+.kv{display:flex;gap:6px;align-items:center}
+
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace}
+
+.pill{
+  display:inline-block;
+  padding:1px 6px;
+  border:2px solid var(--panel-border);
+  border-radius:999px;
+  background:#0e1628;
+}
+
+.hr{height:2px;background:var(--panel-border);margin:8px -8px}
+
+.hint{opacity:.8}
+
+.actions{display:flex;gap:8px;flex-wrap:wrap}
+
+.sml{padding:6px 8px;font-size:12px;border-radius:6px}
+
+.section-title{font-weight:bold;margin:6px 0 4px;color:var(--accent)}
+
+.item-title{font-weight:600}
+
+.green{color:#76d38b}
+.red{color:#ff6b6b}
+
+.gender-card{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  padding:8px;
+  border:2px solid var(--panel-border);
+  border-radius:10px;
+  cursor:pointer;
+}
+.gender-card:hover{background:#25304e}
+.gender-card input{accent-color:var(--accent)}
+
+.gender-preview{
+  width:32px;
+  height:32px;
+  border-radius:6px;
+  background:#0f1119;
+  display:grid;
+  place-items:center;
+}


### PR DESCRIPTION
## Summary
- use external stylesheet for Experimental_UI
- introduce blue panel theme with accent colors
- document experimental UI revamp in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adc0ce27ec8322aa590a8512220747