### PR TITLE
Add character stats page and in-game action log

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@
   #inventory{display:none;position:fixed;right:8px;top:64px;padding:8px 12px;pointer-events:auto;font-size:13px;width:600px;max-width:90vw}
   #shop{display:none;position:fixed;left:8px;top:64px;min-width:320px;padding:10px 12px;pointer-events:auto;font-size:13px}
   #magic{display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);padding:8px 12px;pointer-events:auto;font-size:13px;width:340px;max-width:90vw;max-height:70vh;overflow:auto}
+  #charPage{display:none;position:fixed;top:64px;left:50%;transform:translateX(-50%);padding:8px 12px;pointer-events:auto;font-size:13px;width:320px;max-width:90vw}
+  #actionLog{display:none;position:fixed;bottom:64px;left:50%;transform:translateX(-50%);padding:8px 12px;pointer-events:auto;font-size:13px;width:360px;max-width:90vw;max-height:50vh;overflow:auto}
   .list-row{display:flex;justify-content:space-between;gap:8px;padding:6px 6px;border-radius:6px}
   .inv-grid{display:grid;grid-template-columns:repeat(6,1fr);gap:4px 8px}
   .inv-grid .list-row{flex-direction:column;gap:2px}
@@ -88,6 +90,12 @@
 
 <!-- Shop -->
 <div id="shop" class="panel"></div>
+
+<!-- Character Page -->
+<div id="charPage" class="panel"></div>
+
+<!-- Action Log -->
+<div id="actionLog" class="panel"></div>
 
 <div id="start" class="stone" style="position:fixed;inset:0;display:grid;place-items:center">
   <div class="panel" style="padding:18px 22px;max-width:780px">
@@ -192,6 +200,7 @@ window.addEventListener('resize', resizeCanvas); resizeCanvas();
 let camX=0, camY=0; let floorLayer=null, wallLayer=null;
 let gameOver=false;
 let paused=false;
+let actionLog=[];
 // floor tile from provided image (scaled to 64×64 PNG for smaller payload)
 const FLOOR_DATA =
   "data:image/png;base64," +
@@ -1571,6 +1580,8 @@ window.addEventListener('keydown',e=>{
   if(e.key==='i'||e.key==='I') toggleInv();
   if(e.key==='k'||e.key==='K') toggleMagic();
   if(e.key==='q'||e.key==='Q') castSelectedSpell();
+  if(e.key==='c'||e.key==='C') toggleCharPage();
+  if(e.key==='/') toggleActionLog();
   // quick-use potions from potion bag slots with number keys 1-3
   if(e.key==='1'||e.key==='2'||e.key==='3'){
     const idx = parseInt(e.key,10)-1;
@@ -1610,9 +1621,55 @@ window.addEventListener('keypress',e=>{
 });
 
 // ===== Inventory UI (toggle only) =====
-function updatePaused(){ const inv=document.getElementById('inventory'); const magic=document.getElementById('magic'); const esc=document.getElementById('escMenu'); paused=(inv&&inv.style.display==='block')||(magic&&magic.style.display==='block')||(esc&&esc.style.display==='grid'); }
+function updatePaused(){
+  const inv=document.getElementById('inventory');
+  const magic=document.getElementById('magic');
+  const esc=document.getElementById('escMenu');
+  const charP=document.getElementById('charPage');
+  const log=document.getElementById('actionLog');
+  paused=(inv&&inv.style.display==='block')||(magic&&magic.style.display==='block')||(esc&&esc.style.display==='grid')||(charP&&charP.style.display==='block')||(log&&log.style.display==='block');
+}
 
 function toggleInv(){ let panel=document.getElementById('inventory'); if(!panel){ redrawInventory(); panel=document.getElementById('inventory'); } if(!panel) return; const show=panel.style.display===''||panel.style.display==='none'; panel.style.display=show?'block':'none'; if(show) redrawInventory(); updatePaused(); }
+
+function renderCharPage(){
+  const panel=document.getElementById('charPage');
+  if(!panel) return;
+  let html='<div class="section-title">Character</div>';
+  html+=`<div class="kv">Class: <b>${player.class}</b></div>`;
+  html+=`<div class="kv">HP: <b>${player.hp}/${player.hpMax}</b></div>`;
+  html+=`<div class="kv">Fire Res: <b>${player.resFire||0}%</b></div>`;
+  html+=`<div class="kv">Ice Res: <b>${player.resIce||0}%</b></div>`;
+  html+=`<div class="kv">Shock Res: <b>${player.resShock||0}%</b></div>`;
+  html+=`<div class="kv">Magic Res: <b>${player.resMagic||0}%</b></div>`;
+  panel.innerHTML=html;
+}
+
+function toggleCharPage(){
+  const panel=document.getElementById('charPage');
+  if(!panel) return;
+  const show=panel.style.display===''||panel.style.display==='none';
+  panel.style.display=show?'block':'none';
+  if(show) renderCharPage();
+  updatePaused();
+}
+
+function renderActionLog(){
+  const panel=document.getElementById('actionLog');
+  if(!panel) return;
+  let html='<div class="section-title">Action Log</div>';
+  for(const msg of actionLog){ html+=`<div class="kv">${msg}</div>`; }
+  panel.innerHTML=html;
+}
+
+function toggleActionLog(){
+  const panel=document.getElementById('actionLog');
+  if(!panel) return;
+  const show=panel.style.display===''||panel.style.display==='none';
+  panel.style.display=show?'block':'none';
+  if(show) renderActionLog();
+  updatePaused();
+}
 
 function redrawMagic(){
   let panel=document.getElementById('magic');
@@ -1750,7 +1807,12 @@ function levelUp(){
 }
 
 // ===== Toast =====
-let toastTimer=0; function showToast(msg){ const bar=document.querySelector('.topbar'); const span=document.createElement('span'); span.style.marginLeft='8px'; span.style.opacity=.85; span.textContent='• '+msg; bar.appendChild(span); clearTimeout(toastTimer); toastTimer=setTimeout(()=>{ if(span.parentNode) span.remove(); }, 3000); }
+function showToast(msg){
+  actionLog.push(msg);
+  if(actionLog.length>50) actionLog.shift();
+  const panel=document.getElementById('actionLog');
+  if(panel && panel.style.display==='block') renderActionLog();
+}
 function showRespawn(){ gameOver=true; const d=document.getElementById('respawn'); if(d) d.style.display='grid'; }
 
 // ===== Stats =====


### PR DESCRIPTION
## Summary
- Add a character sheet panel toggled with `C` showing class, HP and resistances
- Redirect toast messages into an action log toggled with `/`
- Pause game when character sheet or log is open

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adc49f51b8832290f50cf539a5ab7c