### PR TITLE
Fix melee handling for spear and flail weapons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1204,13 +1204,13 @@ const WEAPON_RULES = {
 };
 function wclassFromName(n){
   if(!n) return null; const s=n.toLowerCase();
-  for(const k of ['sword','axe','mace','dagger','bow','wand','staff']) if(s.includes(k)) return k;
+  for(const k of ['sword','axe','mace','dagger','bow','wand','staff','spear','halberd','crossbow','flail','katana']) if(s.includes(k)) return k;
   return null;
 }
 function currentWeaponProfile(){
   const it = equip.weapon;
   const wc = it?.wclass || wclassFromName(it?.name) || null;
-  const base = WEAPON_RULES[wc || '_default'];
+  const base = WEAPON_RULES[wc] || WEAPON_RULES._default;
   return {...base};
 }
 function firstMonsterAt(tx,ty){ return monsters.find(mm=>mm.x===tx && mm.y===ty); }


### PR DESCRIPTION
## Summary
- Expand weapon name detection to include spear, flail, and other classes
- Default unrecognized weapon classes to melee profile so they still deal damage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adcc4988988322a2a3b192c4aec01d