### PR TITLE
feat: add stamina-based warrior abilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Additional spells added to each magic tree.
 - Warrior skill tree with 12 abilities and escalating point costs.
 - Stamina resource and Power Strike ability for the Warrior class.
+- Additional warrior stamina abilities: Whirlwind and Shield Bash.
 - Random weapon name generator for unique gear titles.
 - Weapon damage-over-time affix that can ignite foes.
 - Melee weapon classes now inflict bleed damage over time.
@@ -30,6 +31,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Increased potion drop rate to 40% (from 25%).
 - Mage enemies now fire 30% slower but hit 10% harder.
 - Enemy elemental resistances now scale with floor level.
+ - Warrior abilities now unlock sequentially on the skill tree and bind to Q instead of using modifier keys.
 
 ### Fixed
 - Melee attacks now track the mouse and register hits within a 35° cone (2-tile reach by default).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then visit [http://localhost:8000](http://localhost:8000).
 - **I** – Toggle inventory
 - **K** – Toggle magic menu
 - **L** – Toggle warrior skills
-- **Q** – Cast bound spell (mage) / Power Strike (warrior)
+ - **Q** – Use bound ability (spell or warrior skill)
 - **E** – Use stairs or the merchant
 - **1/2/3** – Quick-use potion from potion bag slot 1–3
 - **Click monsters** – Attack

--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@ genSprites();
 let seed=(Math.random()*1e9)|0, floorNum=1, rng=new RNG(seed);
 let map=[], fog=[], vis=[]; let rooms=[]; let stairs={x:0,y:0};
 let merchant={x:0,y:0}; let merchantStyle = Math.random()<0.5 ? 'goblin' : 'stall';
-let player={x:0,y:0,hp:150,hpMax:150,mp:60,mpMax:60,sp:60,spMax:60,gold:0,stepCD:0,stepDelay:140,speedPct:0,lvl:1,xp:0,xpToNext:50,baseAtkBonus:0, gender:'m', class:'warrior', atkCD:0, faceDx:1, faceDy:0, effects:[], magicPoints:0, skillPoints:0, magic:{healing:[false,false,false,false,false,false],damage:[false,false,false,false,false,false],dot:[false,false,false,false,false,false]}, skills:{offense:[false,false,false,false,false,false],defense:[false,false,false,false,false,false]}, boundSpell:null};
+let player={x:0,y:0,hp:150,hpMax:150,mp:60,mpMax:60,sp:60,spMax:60,gold:0,stepCD:0,stepDelay:140,speedPct:0,lvl:1,xp:0,xpToNext:50,baseAtkBonus:0, gender:'m', class:'warrior', atkCD:0, faceDx:1, faceDy:0, effects:[], magicPoints:0, skillPoints:0, magic:{healing:[false,false,false,false,false,false],damage:[false,false,false,false,false,false],dot:[false,false,false,false,false,false]}, skills:{offense:[false,false,false,false,false,false],defense:[false,false,false,false,false,false],techniques:[false,false,false]}, boundSpell:null, boundSkill:null};
 let playerSpriteKey = 'player_m';
 const magicTrees={
   healing:{display:'Healing',abilities:[
@@ -394,12 +394,12 @@ const magicTrees={
 };
 const skillTrees={
   offense:{display:'Offense',abilities:[
-    {name:'Power Strike',bonus:{dmgMin:1,dmgMax:1},cost:1},
-    {name:'Precision',bonus:{crit:5},cost:2},
-    {name:'Berserk',bonus:{dmgMin:2,dmgMax:2},cost:3},
-    {name:'Whirlwind',bonus:{dmgMin:3,dmgMax:3},cost:4},
-    {name:'Cleave',bonus:{dmgMin:4,dmgMax:4},cost:5},
-    {name:'Earthshatter',bonus:{dmgMin:5,dmgMax:5},cost:9}
+    {name:'Precision',bonus:{crit:5},cost:1},
+    {name:'Berserk',bonus:{dmgMin:2,dmgMax:2},cost:2},
+    {name:'Cleave',bonus:{dmgMin:3,dmgMax:3},cost:3},
+    {name:'Earthshatter',bonus:{dmgMin:4,dmgMax:4},cost:4},
+    {name:'Bloodlust',bonus:{dmgMin:5,dmgMax:5},cost:5},
+    {name:'Dominance',bonus:{dmgMin:6,dmgMax:6},cost:9}
   ]},
   defense:{display:'Defense',abilities:[
     {name:'Toughness',bonus:{hpMax:20},cost:1},
@@ -408,6 +408,11 @@ const skillTrees={
     {name:'Stone Skin',bonus:{armor:2},cost:4},
     {name:'Guardian',bonus:{hpMax:30},cost:5},
     {name:'Unbreakable',bonus:{armor:3},cost:9}
+  ]},
+  techniques:{display:'Techniques',abilities:[
+    {name:'Power Strike',cost:1,cast:'powerStrike'},
+    {name:'Whirlwind',cost:2,cast:'whirlwind'},
+    {name:'Shield Bash',cost:3,cast:'shieldBash'}
   ]}
 };
 // Monsters now have richer AI with per-type patterns and scaling
@@ -1671,7 +1676,10 @@ window.addEventListener('keydown',e=>{
   if(e.key==='i'||e.key==='I') toggleInv();
   if(e.key==='k'||e.key==='K') toggleMagic();
   if(e.key==='l'||e.key==='L') toggleSkills();
-  if(e.key==='q'||e.key==='Q'){ if(player.class==='mage') castSelectedSpell(); else castPowerStrike(); }
+  if(e.key==='q'||e.key==='Q'){
+    if(player.class==='mage') castSelectedSpell();
+    else if(player.class==='warrior') castBoundSkill();
+  }
   if(e.key==='c'||e.key==='C') toggleCharPage();
   if(e.key==='/') toggleActionLog();
   // quick-use potions from potion bag slots with number keys 1-3
@@ -1804,13 +1812,18 @@ function redrawSkills(){
   let panel=document.getElementById('skills');
   if(!panel){ panel=document.createElement('div'); panel.id='skills'; panel.className='panel'; document.body.appendChild(panel); }
   let html = `<div class="section-title">Skill Points: ${player.skillPoints}</div>`;
-  for(const treeName of ['offense','defense']){
+  for(const treeName of ['offense','defense','techniques']){
     const tree=skillTrees[treeName];
     html += `<div class="section-title">${tree.display}</div><div>`;
     tree.abilities.forEach((ab,i)=>{
       const unlocked=player.skills[treeName][i];
+      const bind = player.boundSkill && player.boundSkill.tree===treeName && player.boundSkill.idx===i;
       if(unlocked){
-        html += `<div class="list-row"><div>${ab.name}</div><div><span class="green">Unlocked</span></div></div>`;
+        if(ab.cast){
+          html += `<div class="list-row"><div>${ab.name}</div><div>${bind?'<span class="green">Bound</span>':`<button class="btn sml" data-bind="${treeName}-${i}">Bind</button>`}</div></div>`;
+        }else{
+          html += `<div class="list-row"><div>${ab.name}</div><div><span class="green">Unlocked</span></div></div>`;
+        }
       }else{
         const prevUnlocked = i===0 || player.skills[treeName][i-1];
         const dis=(player.skillPoints<ab.cost || !prevUnlocked)?'disabled':'';
@@ -1820,7 +1833,11 @@ function redrawSkills(){
     html += '</div>';
   }
   panel.innerHTML=html;
-  panel.onclick=(e)=>{ const b=e.target.closest('button'); if(!b) return; const [t,i]=b.dataset.unlock.split('-'); unlockSkill(t,parseInt(i,10)); redrawSkills(); };
+  panel.onclick=(e)=>{
+    const b=e.target.closest('button'); if(!b) return;
+    if(b.dataset.unlock){ const [t,i]=b.dataset.unlock.split('-'); unlockSkill(t,parseInt(i,10)); redrawSkills(); }
+    if(b.dataset.bind){ const [t,i]=b.dataset.bind.split('-'); bindSkill(t,parseInt(i,10)); redrawSkills(); }
+  };
 }
 
 function toggleSkills(){ if(player.class!=='warrior') return; let panel=document.getElementById('skills'); if(!panel){ redrawSkills(); panel=document.getElementById('skills'); } if(!panel) return; const show=panel.style.display===''||panel.style.display==='none'; panel.style.display=show?'block':'none'; if(show) redrawSkills(); updatePaused(); }
@@ -1831,6 +1848,14 @@ function unlockSkill(treeName, idx){
   if(idx>0 && !player.skills[treeName][idx-1]){ showToast('Unlock previous ability first'); return; }
   if(player.skillPoints>=ab.cost){ player.skillPoints-=ab.cost; player.skills[treeName][idx]=true; showToast(`Unlocked ${ab.name}`); recalcStats(); }
   else showToast('Not enough points');
+}
+
+function bindSkill(treeName, idx){
+  if(!player.skills[treeName][idx]){ showToast('Ability not unlocked'); return; }
+  player.boundSkill={tree:treeName, idx};
+  const ab=skillTrees[treeName].abilities[idx];
+  hudSpell.textContent=ab.name;
+  showToast(`Bound ${ab.name} to Q`);
 }
 
 function unlockSpell(treeName, idx){
@@ -1872,11 +1897,74 @@ function castSelectedSpell(){
   projectiles.push({x:player.x+0.5,y:player.y+0.5,dx,dy,speed:12,damage:dmg,type:'magic',elem:ab.elem||null,owner:'player',alive:true,maxDist:ab.range||8,dist:0,status:ab.status||null});
 }
 
+function castBoundSkill(){
+  const b=player.boundSkill; if(!b){ showToast('No skill bound'); return; }
+  const ab=skillTrees[b.tree].abilities[b.idx];
+  if(!player.skills[b.tree][b.idx]){ showToast('Skill locked'); return; }
+  if(ab.cast==='powerStrike') castPowerStrike();
+  else if(ab.cast==='whirlwind') castWhirlwind();
+  else if(ab.cast==='shieldBash') castShieldBash();
+}
+
 function castPowerStrike(){
   const cost=20;
   if(player.sp<cost){ showToast('Not enough stamina'); return; }
   player.sp-=cost; updateResourceUI();
   performPlayerAttack(player.faceDx, player.faceDy, 2);
+}
+
+function castWhirlwind(){
+  const cost=30;
+  if(player.sp<cost){ showToast('Not enough stamina'); return; }
+  if(player.atkCD>0) return;
+  player.sp-=cost; updateResourceUI();
+  const {min,max,crit,ls} = currentAtk();
+  const prof=currentWeaponProfile();
+  let hit=false;
+  for(const m of monsters){
+    const dist=Math.hypot(m.x-player.x, m.y-player.y);
+    if(dist<=1.5){
+      let dmg=rng.int(min,max);
+      const wasCrit=Math.random()*100<crit; if(wasCrit) dmg=Math.floor(dmg*1.5);
+      dealDamageToMonster(m,dmg,null,wasCrit);
+      if(ls>0){ const heal=Math.max(1,Math.floor(dmg*ls/100)); player.hp=Math.min(player.hpMax,player.hp+heal); addDamageText(player.x,player.y,`+${heal}`,'#76d38b'); }
+      hit=true;
+    }
+  }
+  if(hit) playAttack();
+  player.atkCD = prof.cooldown*1.5;
+}
+
+function castShieldBash(){
+  const cost=15;
+  if(player.sp<cost){ showToast('Not enough stamina'); return; }
+  if(player.atkCD>0) return;
+  player.sp-=cost; updateResourceUI();
+  const {min,max,crit,ls}=currentAtk();
+  const prof=currentWeaponProfile();
+  let dmg=rng.int(min,max);
+  const wasCrit=Math.random()*100<crit; if(wasCrit) dmg=Math.floor(dmg*1.5);
+  dmg=Math.floor(dmg*1.2);
+  const reach=prof.reach ?? 2;
+  const cone=(prof.cone || 35) * Math.PI/180;
+  const ndx=player.faceDx, ndy=player.faceDy;
+  let target=null,bestDist=Infinity;
+  for(const m of monsters){
+    const dxm=m.x-player.x, dym=m.y-player.y;
+    const dist=Math.hypot(dxm,dym);
+    if(dist>reach || dist===0) continue;
+    const ang=Math.acos((ndx*dxm+ndy*dym)/dist);
+    if(ang>cone/2) continue;
+    if(!clearPath8(player.x,player.y,m.x,m.y)) continue;
+    if(dist<bestDist){ target=m; bestDist=dist; }
+  }
+  if(target){
+    dealDamageToMonster(target,dmg,null,wasCrit);
+    tryApplyStatus(target,{k:'shock',dur:1200,power:0.5,chance:1},'shock');
+    if(ls>0){ const heal=Math.max(1,Math.floor(dmg*ls/100)); player.hp=Math.min(player.hpMax,player.hp+heal); addDamageText(player.x,player.y,`+${heal}`,'#76d38b'); }
+    playAttack();
+  }
+  player.atkCD = prof.cooldown;
 }
 
 function toggleEscMenu(force){
@@ -1906,10 +1994,11 @@ function loadGame(){
     while(player.magic[t].length < magicTrees[t].abilities.length) player.magic[t].push(false);
   }
   player.skills = player.skills || {};
-  for(const t of ['offense','defense']){
+  for(const t of ['offense','defense','techniques']){
     player.skills[t] = player.skills[t] || [];
     while(player.skills[t].length < skillTrees[t].abilities.length) player.skills[t].push(false);
   }
+  if(player.boundSkill===undefined) player.boundSkill=null;
   bag=data.bag||new Array(BAG_SIZE).fill(null);
   potionBag=data.potionBag||new Array(POTION_BAG_SIZE).fill(null);
   equip=data.equip||{helmet:null,chest:null,legs:null,hands:null,feet:null,weapon:null};
@@ -1917,7 +2006,9 @@ function loadGame(){
   player.rx=player.x; player.ry=player.y; player.fromX=player.x; player.fromY=player.y; player.toX=player.x; player.toY=player.y; player.moving=false; player.moveT=1;
   recalcStats(); recomputeFOV(); redrawInventory();
   hudAbilityLabel.textContent = player.class==='mage'?'Spell:':'Skill:';
-  hudSpell.textContent = player.class==='warrior' ? 'Power Strike' : (player.boundSpell ? magicTrees[player.boundSpell.tree].abilities[player.boundSpell.idx].name : 'None');
+  hudSpell.textContent = player.class==='warrior'
+    ? (player.boundSkill ? skillTrees[player.boundSkill.tree].abilities[player.boundSkill.idx].name : 'None')
+    : (player.boundSpell ? magicTrees[player.boundSpell.tree].abilities[player.boundSpell.idx].name : 'None');
   updateResourceUI();
   toggleEscMenu(false); showToast('Game loaded');
 }
@@ -2028,6 +2119,7 @@ function startGame(){
   // class pick -> stats
   const cSel = document.querySelector('input[name="class"]:checked');
   player.class = (cSel?.value==='mage')?'mage':'warrior';
+  player.boundSpell=null; player.boundSkill=null;
   hudAbilityLabel.textContent = player.class==='mage'?'Spell:':'Skill:';
   hudFloor.textContent=floorNum; hudSeed.textContent=seed>>>0; hudGold.textContent=player.gold; hudLvl.textContent=player.lvl;
   generate(); recalcStats();
@@ -2036,7 +2128,9 @@ function startGame(){
   hpFill.style.width = `100%`; updateResourceUI();
   hpLbl.textContent = `HP ${player.hp}/${player.hpMax}`;
   recomputeFOV();
-  hudSpell.textContent = player.class==='warrior' ? 'Power Strike' : (player.boundSpell ? magicTrees[player.boundSpell.tree].abilities[player.boundSpell.idx].name : 'None');
+  hudSpell.textContent = player.class==='warrior'
+    ? (player.boundSkill ? skillTrees[player.boundSkill.tree].abilities[player.boundSkill.idx].name : 'None')
+    : (player.boundSpell ? magicTrees[player.boundSpell.tree].abilities[player.boundSpell.idx].name : 'None');
   const smoothToggle=document.getElementById('smoothToggle'); const speedRange=document.getElementById('speedRange');
   if(smoothToggle){ smoothToggle.checked = smoothEnabled; smoothToggle.addEventListener('change', e=>{ smoothEnabled = e.target.checked; if(!smoothEnabled){ player.rx=player.x; player.ry=player.y; } }); }
   if(speedRange){ baseStepDelay = player.stepDelay; speedRange.value = String(baseStepDelay); speedRange.addEventListener('input', e=>{ const v=parseInt(e.target.value,10); if(!isNaN(v)) baseStepDelay=v; }); }


### PR DESCRIPTION
## Summary
- gate warrior combat skills behind Techniques tree with sequential unlocks
- bind a single warrior skill to Q like mage spells and update controls
- document unified Q ability usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68add08ffbc4832292af7ad125d72b9d