### PR TITLE
feat: add weapon affix variety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Random weapon name generator for unique gear titles.
 - Weapon damage-over-time affix that can ignite foes.
 - Melee weapon classes now inflict bleed damage over time.
+- New weapon affixes: attack speed, knockback, and projectile pierce.
 
 - Consumable potions appear in loot and shop inventories.
 - Legendary rarity added for gear and weapon drops.

--- a/index.html
+++ b/index.html
@@ -748,10 +748,16 @@ function affixMods(slot){
     if(rng.next()<0.35) R.crit=rng.int(3,8);
     if(rng.next()<0.2) R.ls=rng.int(1,5);
     if(rng.next()<0.2) R.mp=rng.int(1,4);
-    if(rng.next()<0.2){
-      if(rng.next()<0.5) R.status={k:'burn',dur:2200,power:1.0,chance:rng.int(10,30)/100,elem:'fire'};
-      else R.status={k:'bleed',dur:2000,power:1.0,chance:rng.int(10,30)/100,elem:'bleed'};
+    if(rng.next()<0.25){
+      const roll=rng.int(0,3);
+      if(roll===0) R.status={k:'burn',dur:2200,power:1.0,chance:rng.int(10,30)/100,elem:'fire'};
+      else if(roll===1) R.status={k:'bleed',dur:2000,power:1.0,chance:rng.int(10,30)/100,elem:'bleed'};
+      else if(roll===2) R.status={k:'freeze',dur:1800,power:0.4,chance:rng.int(10,30)/100,elem:'ice'};
+      else R.status={k:'shock',dur:2000,power:0.25,chance:rng.int(10,30)/100,elem:'shock'};
     }
+    if(rng.next()<0.2) R.kb=rng.int(1,2);
+    if(rng.next()<0.2) R.atkSpd=rng.int(5,15);
+    if(rng.next()<0.15) R.pierce=rng.int(1,2);
   }else{
     if(rng.next()<0.6) R.armor=rng.int(2,6);
     if(rng.next()<0.35) R.resFire=rng.int(5,15);
@@ -944,6 +950,9 @@ function shortMods(it){
   if(m.speedPct) bits.push(`SPD+${m.speedPct}%`);
   if(m.ls) bits.push(`LS ${m.ls}%`);
   if(m.mp) bits.push(`MPo+${m.mp}`);
+  if(m.atkSpd) bits.push(`AS+${m.atkSpd}%`);
+  if(m.kb) bits.push(`KB ${m.kb}`);
+  if(m.pierce) bits.push(`PRC ${m.pierce}`);
   if(m.status) bits.push(`${m.status.k.toUpperCase()} ${Math.round((m.status.chance||0)*100)}%`);
   const rf=m.resFire||0, ri=m.resIce||0, rs=m.resShock||0, rm=m.resMagic||0;
   if(rf||ri||rs||rm) bits.push(`RES F/I/S/M ${rf}/${ri}/${rs}/${rm}`);
@@ -973,6 +982,9 @@ function renderDetails(it, origin){
   if(m.speedPct) rows.push(`<div>Speed: <span class="mono">+${m.speedPct}%</span></div>`);
   if(m.ls) rows.push(`<div>Lifesteal: <span class="mono">${m.ls}%</span></div>`);
   if(m.mp) rows.push(`<div>${player.class==='mage'?'Mana':'Stamina'} on hit: <span class="mono">+${m.mp}</span></div>`);
+  if(m.atkSpd) rows.push(`<div>Attack Speed: <span class="mono">+${m.atkSpd}%</span></div>`);
+  if(m.kb) rows.push(`<div>Knockback: <span class="mono">${m.kb}</span></div>`);
+  if(m.pierce) rows.push(`<div>Projectile Pierce: <span class="mono">${m.pierce}</span></div>`);
   if(m.status) rows.push(`<div>${m.status.k.toUpperCase()} Chance: <span class="mono">${Math.round((m.status.chance||0)*100)}%</span></div>`);
   if(m.resFire||m.resIce||m.resShock||m.resMagic){
     rows.push(`<div>Resists (F/I/S/M): <span class="mono">${m.resFire||0}/${m.resIce||0}/${m.resShock||0}/${m.resMagic||0}%</span></div>`);
@@ -1000,6 +1012,7 @@ function getItemValue(it){
   score+= (m.crit||0)*3 + (m.armor||0)*3;
   score+= (m.hpMax||0)*0.8 + (m.mpMax||0)*0.6 + (m.speedPct||0)*4;
   score+= (m.ls||0)*6 + (m.mp||0)*2;
+  score+= (m.atkSpd||0)*4 + (m.kb||0)*8 + (m.pierce||0)*12;
   if(m.status) score+= Math.round((m.status.chance||0)*100) * 4;
   score+= ((m.resFire||0)+(m.resIce||0)+(m.resShock||0))*1.2 + (m.resMagic||0)*1.8;
   const floorBonus = Math.max(0,floorNum-1)*4;
@@ -1263,6 +1276,10 @@ function performPlayerAttack(dx,dy,dmgMult=1){
   dmg=Math.max(1,Math.floor(dmg*dmgMult));
   const wStatus = equip.weapon?.mods?.status || null;
   const atkStatus = wStatus || prof.status || null;
+  const wmods = equip.weapon?.mods || {};
+  const kb = wmods.kb || 0;
+  const aspd = wmods.atkSpd || 0;
+  const pierce = wmods.pierce || 0;
   if(prof.kind==='melee'){
     const reach = prof.reach ?? 2;
     const cone = (prof.cone || 35) * Math.PI / 180;
@@ -1280,17 +1297,25 @@ function performPlayerAttack(dx,dy,dmgMult=1){
       dealDamageToMonster(target, dmg, null, wasCrit);
       if(atkStatus) tryApplyStatus(target, atkStatus, atkStatus.elem);
       if(ls>0){ const heal=Math.max(1,Math.floor(dmg*ls/100)); player.hp=Math.min(player.hpMax, player.hp+heal); addDamageText(player.x,player.y,`+${heal}`,'#76d38b'); }
+      if(kb>0){
+        const kdx=Math.sign(ndx), kdy=Math.sign(ndy);
+        for(let i=0;i<kb;i++){ if(!tryMoveMonster(target,kdx,kdy)) break; }
+      }
     }
-    player.atkCD = prof.cooldown;
+    let cd = prof.cooldown;
+    if(aspd>0) cd = Math.max(60, Math.floor(cd * (1 - aspd/100)));
+    player.atkCD = cd;
   } else {
     // ranged projectile
     projectiles.push({
       x: player.x+0.5, y: player.y+0.5, dx: ndx, dy: ndy,
       speed: prof.projSpeed, damage:dmg, type: prof.dtype||'ranged', elem: atkStatus?.elem || prof.elem || null,
       owner:'player', alive:true, maxDist: prof.projRange, dist:0, ls,
-      status: atkStatus
+      status: atkStatus, kb, pierce
     });
-    player.atkCD = prof.cooldown;
+    let cd = prof.cooldown;
+    if(aspd>0) cd = Math.max(60, Math.floor(cd * (1 - aspd/100)));
+    player.atkCD = cd;
   }
 }
 
@@ -1658,7 +1683,12 @@ function update(dt){
         dealDamageToMonster(m, p.damage, p.elem||null, false);
         if(p.status) tryApplyStatus(m, p.status, p.elem);
         if(p.ls>0){ const heal=Math.max(1,Math.floor(p.damage*p.ls/100)); player.hp=Math.min(player.hpMax, player.hp+heal); addDamageText(player.x,player.y,`+${heal}`,'#76d38b'); }
-        p.alive=false;
+        if(p.kb>0){
+          const kdx=Math.sign(p.dx), kdy=Math.sign(p.dy);
+          for(let i=0;i<p.kb;i++){ if(!tryMoveMonster(m,kdx,kdy)) break; }
+        }
+        if(p.pierce>0){ p.pierce--; }
+        else{ p.alive=false; }
       }
     }
     // range limit


### PR DESCRIPTION
## Summary
- expand weapon loot to include attack speed, knockback, freeze/shock and projectile pierce affixes
- hook new affixes into combat and projectile handling
- document new weapon modifiers in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68addbae7cb8832295d763eb4608367d