### PR TITLE
Add controls page and normalize key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Then visit [http://localhost:8000](http://localhost:8000).
 - **I** – Toggle inventory
 - **K** – Toggle magic menu
 - **L** – Toggle warrior skills
- - **Q** – Use bound ability (spell or warrior skill)
+- **Q** – Use bound ability (spell or warrior skill)
 - **E** – Use stairs or the merchant
 - **1/2/3** – Quick-use potion from potion bag slot 1–3
 - **Click monsters** – Attack
+
+See [`controls.html`](controls.html) for a standalone controls page.
 
 ## Development Notes
 - All game logic, styling, and assets live inline within `index.html` to keep the project self-contained.

--- a/controls.html
+++ b/controls.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Dungeon Controls</title>
+<style>
+  body{font-family:system-ui,Segoe UI,Roboto,Ubuntu,Arial,sans-serif;background:#0b0b0e;color:#ddd;padding:20px;line-height:1.6}
+  h1{margin-top:0}
+  ul{list-style:disc;padding-left:20px}
+  a{color:#7a4bd9}
+</style>
+</head>
+<body>
+<h1>Controls</h1>
+<ul>
+  <li><strong>WASD or Arrow Keys</strong> – Move in eight directions</li>
+  <li><strong>I</strong> – Toggle inventory</li>
+  <li><strong>K</strong> – Toggle magic menu</li>
+  <li><strong>L</strong> – Toggle warrior skills</li>
+  <li><strong>Q</strong> – Use bound ability (spell or warrior skill)</li>
+  <li><strong>E</strong> – Use stairs or the merchant</li>
+  <li><strong>1/2/3</strong> – Quick-use potion from potion bag slot 1–3</li>
+  <li><strong>F</strong> – Sell hovered inventory item</li>
+  <li><strong>Click monsters</strong> – Attack</li>
+</ul>
+<p><a href="index.html">Back to game</a></p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1615,10 +1615,10 @@ function update(dt){
   // inputs
   player.stepCD = Math.max(0, player.stepCD - dt);
   if(player.stepCD<=0 && !player.moving){
-    const up=!!(keys['ArrowUp']||keys['w']||keys['W']);
-    const down=!!(keys['ArrowDown']||keys['s']||keys['S']);
-    const left=!!(keys['ArrowLeft']||keys['a']||keys['A']);
-    const right=!!(keys['ArrowRight']||keys['d']||keys['D']);
+    const up=!!(keys['arrowup']||keys['w']);
+    const down=!!(keys['arrowdown']||keys['s']);
+    const left=!!(keys['arrowleft']||keys['a']);
+    const right=!!(keys['arrowright']||keys['d']);
     const dx = (right && !left) ? 1 : (left && !right) ? -1 : 0;
     const dy = (down && !up) ? 1 : (up && !down) ? -1 : 0;
     if(dx||dy){
@@ -1703,23 +1703,32 @@ function update(dt){
 // ===== Input =====
 const keys={};
 window.addEventListener('keydown',e=>{
-  keys[e.key]=true;
-  if(e.key==='Escape'){ toggleEscMenu(); return; }
-  if(e.key==='i'||e.key==='I') toggleInv();
-  if(e.key==='k'||e.key==='K'){
+  const key=e.key.toLowerCase();
+  keys[key]=true;
+  if(key==='escape'){ toggleEscMenu(); return; }
+  if(key==='i') toggleInv();
+  if(key==='k'){
     if(player.class==='mage') toggleMagic();
     else toggleSkills();
   }
-  if(e.key==='l'||e.key==='L') toggleSkills();
-  if(e.key==='q'||e.key==='Q'){
+  if(key==='l') toggleSkills();
+  if(key==='q'){
     if(player.class==='mage') castSelectedSpell();
     else if(player.class==='warrior') castBoundSkill();
   }
-  if(e.key==='c'||e.key==='C') toggleCharPage();
-  if(e.key==='/') toggleActionLog();
+  if(key==='c') toggleCharPage();
+  if(key==='/') toggleActionLog();
+  if(key==='e' && !e.repeat){
+    if(player.x===stairs.x && player.y===stairs.y){
+      floorNum++; seed=(seed*1664525+1013904223)|0; rng=new RNG(seed);
+      generate(); hudFloor.textContent=floorNum; hudSeed.textContent=seed>>>0; showToast('Down we go'); toggleShop(false);
+    } else if(player.x===merchant.x && player.y===merchant.y){
+      toggleShop(document.getElementById('shop').style.display!=='block'); renderShop();
+    }
+  }
   // quick-use potions from potion bag slots with number keys 1-3
-  if(e.key==='1'||e.key==='2'||e.key==='3'){
-    const idx = parseInt(e.key,10)-1;
+  if(key==='1'||key==='2'||key==='3'){
+    const idx = parseInt(key,10)-1;
     const it = potionBag[idx];
     if(it){
       usePotion(it);
@@ -1729,7 +1738,7 @@ window.addEventListener('keydown',e=>{
     }
   }
   // sell hovered inventory item with F key
-  if(e.key==='f' || e.key==='F'){
+  if(key==='f'){
     const panel=document.getElementById('inventory');
     if(panel && panel.style.display==='block'){
       const det=document.getElementById('invDetails');
@@ -1742,18 +1751,11 @@ window.addEventListener('keydown',e=>{
       }
     }
   }
-});
-// Space to attack in facing direction
-window.addEventListener('keydown',e=>{ if(e.code==='Space'){ performPlayerAttack(player.faceDx, player.faceDy); } });
-window.addEventListener('keyup',e=>{ keys[e.key]=false; });
-window.addEventListener('keypress',e=>{
-  if(e.key==='e'||e.key==='E'){
-    if(player.x===stairs.x && player.y===stairs.y){
-      floorNum++; seed=(seed*1664525+1013904223)|0; rng=new RNG(seed);
-      generate(); hudFloor.textContent=floorNum; hudSeed.textContent=seed>>>0; showToast('Down we go'); toggleShop(false);
-    } else if(player.x===merchant.x && player.y===merchant.y){ toggleShop(document.getElementById('shop').style.display!=='block'); renderShop(); }
+  if(e.code==='Space'){
+    performPlayerAttack(player.faceDx, player.faceDy);
   }
 });
+window.addEventListener('keyup',e=>{ keys[e.key.toLowerCase()]=false; });
 
 // ===== Inventory UI (toggle only) =====
 function updatePaused(){


### PR DESCRIPTION
## Summary
- Normalize keyboard input by converting `e.key` to lowercase and streamlining keybindings
- Add standalone controls page and link from README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade5611dec8322ac432e509807e99b