### PR TITLE
Rebalance early ability damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Increased potion drop rate to 40% (from 25%).
 - Mage enemies now fire 30% slower but hit 10% harder.
 - Enemy elemental resistances now scale with floor level.
- - Warrior abilities now unlock sequentially on the skill tree and bind to Q instead of using modifier keys.
+- Warrior abilities now unlock sequentially on the skill tree and bind to Q instead of using modifier keys.
+- Adjusted special ability damage scaling for Mage and Warrior classes, weakening early skills and strengthening later unlocks.
 
 ### Fixed
 - Melee attacks now track the mouse and register hits within a 35° cone (2-tile reach by default).

--- a/index.html
+++ b/index.html
@@ -376,20 +376,20 @@ const magicTrees={
     {name:'Divine Light',type:'heal',value:null,mp:80,cost:9}
   ]},
   damage:{display:'Damage',abilities:[
-    {name:'Fire Bolt',type:'damage',dmg:25,mp:10,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2000,power:1.0,chance:1}},
-    {name:'Ice Spike',type:'damage',dmg:35,mp:15,cost:2,range:8,elem:'ice',status:{k:'freeze',dur:1800,power:0.4,chance:1}},
-    {name:'Lightning Bolt',type:'damage',dmg:50,mp:20,cost:3,range:9,elem:'shock',status:{k:'shock',dur:2000,power:0.25,chance:1}},
-    {name:'Arcane Blast',type:'damage',dmg:70,mp:30,cost:4,range:9,elem:'magic'},
-    {name:'Meteor',type:'damage',dmg:90,mp:40,cost:5,range:9,elem:'fire',status:{k:'burn',dur:3000,power:1.5,chance:1}},
-    {name:'Void Ray',type:'damage',dmg:130,mp:60,cost:9,range:10,elem:'magic'}
+    {name:'Fire Bolt',type:'damage',dmg:15,mp:10,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2000,power:1.0,chance:1}},
+    {name:'Ice Spike',type:'damage',dmg:40,mp:15,cost:2,range:8,elem:'ice',status:{k:'freeze',dur:1800,power:0.4,chance:1}},
+    {name:'Lightning Bolt',type:'damage',dmg:65,mp:20,cost:3,range:9,elem:'shock',status:{k:'shock',dur:2000,power:0.25,chance:1}},
+    {name:'Arcane Blast',type:'damage',dmg:90,mp:30,cost:4,range:9,elem:'magic'},
+    {name:'Meteor',type:'damage',dmg:120,mp:40,cost:5,range:9,elem:'fire',status:{k:'burn',dur:3000,power:1.5,chance:1}},
+    {name:'Void Ray',type:'damage',dmg:150,mp:60,cost:9,range:10,elem:'magic'}
   ]},
   dot:{display:'Damage Over Time',abilities:[
-    {name:'Ignite',type:'dot',dmg:10,mp:12,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2200,power:1.0,chance:1}},
-    {name:'Scorch',type:'dot',dmg:15,mp:16,cost:2,range:8,elem:'fire',status:{k:'burn',dur:2600,power:1.1,chance:1}},
-    {name:'Sear',type:'dot',dmg:20,mp:20,cost:3,range:8,elem:'fire',status:{k:'burn',dur:3000,power:1.2,chance:1}},
-    {name:'Inferno',type:'dot',dmg:25,mp:25,cost:4,range:8,elem:'fire',status:{k:'burn',dur:3400,power:1.3,chance:1}},
-    {name:'Conflagrate',type:'dot',dmg:30,mp:28,cost:5,range:8,elem:'fire',status:{k:'burn',dur:3800,power:1.4,chance:1}},
-    {name:'Hellfire',type:'dot',dmg:40,mp:35,cost:9,range:8,elem:'fire',status:{k:'burn',dur:4200,power:1.5,chance:1}}
+    {name:'Ignite',type:'dot',dmg:8,mp:12,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2200,power:1.0,chance:1}},
+    {name:'Scorch',type:'dot',dmg:18,mp:16,cost:2,range:8,elem:'fire',status:{k:'burn',dur:2600,power:1.1,chance:1}},
+    {name:'Sear',type:'dot',dmg:28,mp:20,cost:3,range:8,elem:'fire',status:{k:'burn',dur:3000,power:1.2,chance:1}},
+    {name:'Inferno',type:'dot',dmg:38,mp:25,cost:4,range:8,elem:'fire',status:{k:'burn',dur:3400,power:1.3,chance:1}},
+    {name:'Conflagrate',type:'dot',dmg:48,mp:28,cost:5,range:8,elem:'fire',status:{k:'burn',dur:3800,power:1.4,chance:1}},
+    {name:'Hellfire',type:'dot',dmg:60,mp:35,cost:9,range:8,elem:'fire',status:{k:'burn',dur:4200,power:1.5,chance:1}}
   ]}
 };
 const skillTrees={
@@ -1947,7 +1947,7 @@ function castPowerStrike(){
   const cost=20;
   if(player.sp<cost){ showToast('Not enough stamina'); return; }
   player.sp-=cost; updateResourceUI();
-  performPlayerAttack(player.faceDx, player.faceDy, 2);
+  performPlayerAttack(player.faceDx, player.faceDy, 1.4);
 }
 
 function castWhirlwind(){
@@ -1963,6 +1963,7 @@ function castWhirlwind(){
     if(dist<=1.5){
       let dmg=rng.int(min,max);
       const wasCrit=Math.random()*100<crit; if(wasCrit) dmg=Math.floor(dmg*1.5);
+      dmg=Math.floor(dmg*1.6);
       dealDamageToMonster(m,dmg,null,wasCrit);
       if(ls>0){ const heal=Math.max(1,Math.floor(dmg*ls/100)); player.hp=Math.min(player.hpMax,player.hp+heal); addDamageText(player.x,player.y,`+${heal}`,'#76d38b'); }
       hit=true;
@@ -1981,7 +1982,7 @@ function castShieldBash(){
   const prof=currentWeaponProfile();
   let dmg=rng.int(min,max);
   const wasCrit=Math.random()*100<crit; if(wasCrit) dmg=Math.floor(dmg*1.5);
-  dmg=Math.floor(dmg*1.2);
+  dmg=Math.floor(dmg*1.8);
   const reach=prof.reach ?? 2;
   const cone=(prof.cone || 35) * Math.PI/180;
   const ndx=player.faceDx, ndy=player.faceDy;


### PR DESCRIPTION
## Summary
- Tone down beginner ability damage for mage and warrior while boosting later unlocks
- Clarify new scaling in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adedaf0c408322abf151a13ed68bfb