### PR TITLE
feat: add large boss variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Uncommon rarity tier and revamped color scheme; rarer weapons gain stronger stats and glow from Rare upward.
 - Torches now cast light, revealing nearby tiles for increased visibility.
 - Subtle floor and wall color variations between floors for greater variety.
+- Griffin, dragon, and snake boss variants.
 
 ### Changed
 - Recombined CSS and JavaScript into `index.html` to maintain a single-file distribution.
@@ -40,6 +41,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Warrior abilities now unlock sequentially on the skill tree and bind to Q instead of using modifier keys.
 - Adjusted special ability damage scaling for Mage and Warrior classes, weakening early skills and strengthening later unlocks.
 - Rebalanced loot rarity distribution to favor common and uncommon gear and increased bonuses on rare items.
+- Mini bosses and bosses now appear at twice the size of normal monsters.
 
 ### Fixed
 - Melee attacks now track the mouse and register hits within a 35° cone (2-tile reach by default).

--- a/index.html
+++ b/index.html
@@ -201,6 +201,8 @@ const SCORE_PER_SECOND = 1;
 const SCORE_PER_KILL = 10;
 const SCORE_PER_FLOOR_CLEAR = 100;
 const SCORE_PER_FLOOR_REACHED = 50;
+const BOSS_VARIANTS=['griffin','dragon','snake'];
+function randomBossVariant(){ return BOSS_VARIANTS[rng.int(0,BOSS_VARIANTS.length-1)]; }
 function monsterCountForFloor(floor){
   const dec=(floor-1)*MONSTER_COUNT_DECAY;
   let count = MONSTER_BASE_COUNT - dec;
@@ -330,6 +332,37 @@ function genSprites(){
     px(g,8,2,8,4,'#e6c9a6'); px(g,9,3,2,2,'#000'); px(g,13,3,2,2,'#000');
     // staff/glow
     px(g,3,6,2,14,'#7a5cff'); px(g,2,6,4,2,'#b84aff');
+    outline(g,S);
+  });
+
+  // Boss variants 48x48
+  SPRITES.griffin = makeSprite(48,(g,S)=>{
+    // wings
+    px(g,6,18,36,12,'#b88f4a');
+    // body
+    px(g,16,24,16,16,'#c8a14a');
+    // head
+    px(g,20,12,8,8,'#e0c272');
+    // legs
+    px(g,18,40,4,8,'#8c6239'); px(g,26,40,4,8,'#8c6239');
+    outline(g,S);
+  });
+  SPRITES.dragon = makeSprite(48,(g,S)=>{
+    // wings
+    px(g,4,16,16,8,'#b33'); px(g,28,16,16,8,'#b33');
+    // body
+    px(g,12,24,24,16,'#a22');
+    // head
+    px(g,32,12,12,12,'#a22');
+    outline(g,S);
+  });
+  SPRITES.snake = makeSprite(48,(g,S)=>{
+    // body
+    px(g,8,28,32,8,'#3a8');
+    // neck
+    px(g,20,16,8,12,'#3a8');
+    // head
+    px(g,16,12,16,8,'#3a8');
     outline(g,S);
   });
 
@@ -631,6 +664,8 @@ function generate(){
       const mb=spawnMonster(strongest.type,x,y);
       mb.hpMax = mb.hp = Math.round(strongest.hpMax * 1.8);
       mb.miniBoss = true;
+      mb.spriteKey = randomBossVariant();
+      mb.spriteSize = 48;
       monsters.push(mb);
       placed=true;
     }
@@ -649,6 +684,8 @@ function generate(){
         bb.dmgMin = Math.round(bb.dmgMin * 2);
         bb.dmgMax = Math.round(bb.dmgMax * 2);
         bb.bigBoss = true;
+        bb.spriteKey = randomBossVariant();
+        bb.spriteSize = 48;
         monsters.push(bb);
         placed=true;
       }
@@ -1642,15 +1679,16 @@ function draw(dt){
     if(!vis[m.y*MAP_W+m.x]) continue;
     const mtx = (m.rx!==undefined ? m.rx : m.x);
     const mty = (m.ry!==undefined ? m.ry : m.y);
-    const mx = mtx*TILE - camX + (TILE-24)/2; const my = mty*TILE - camY + (TILE-24)/2;
-    const key = m.type===0?'slime' : m.type===1?'bat' : m.type===2?'skeleton' : 'mage';
+    const size = m.spriteSize || 24;
+    const mx = mtx*TILE - camX + (TILE-size)/2; const my = mty*TILE - camY + (TILE-size)/2;
+    const key = m.spriteKey || (m.type===0?'slime' : m.type===1?'bat' : m.type===2?'skeleton' : 'mage');
     ctx.drawImage(SPRITES[key].cv, mx, my);
-    if(m.hitFlash>0){ ctx.globalAlpha=0.5; ctx.fillStyle='#ff6666'; ctx.fillRect(mx,my,24,24); ctx.globalAlpha=1; }
+    if(m.hitFlash>0){ ctx.globalAlpha=0.5; ctx.fillStyle='#ff6666'; ctx.fillRect(mx,my,size,size); ctx.globalAlpha=1; }
     // hp bar
-    ctx.fillStyle='#111'; ctx.fillRect(mx, my-6, 24, 3);
-    ctx.fillStyle='#e33'; const hw=24*(Math.max(0,m.hp)/m.hpMax); ctx.fillRect(mx, my-6, hw, 3);
+    ctx.fillStyle='#111'; ctx.fillRect(mx, my-6, size, 3);
+    ctx.fillStyle='#e33'; const hw=size*(Math.max(0,m.hp)/m.hpMax); ctx.fillRect(mx, my-6, hw, 3);
     // status pips over bar
-    drawStatusPips(ctx, m, mx+12, my-9);
+    drawStatusPips(ctx, m, mx+size/2, my-9);
     if(m.hitFlash>0) m.hitFlash--;
     if(m.hp<=0){
       player.kills++; player.score += SCORE_PER_KILL; updateScoreUI();


### PR DESCRIPTION
## Summary
- spawn mini and big bosses with randomized griffin, dragon, or snake sprites
- render bosses at double size compared to regular monsters
- document new boss variants and size change in changelog

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae61abb2708322b3add88b52a2fcec