### PR TITLE
feat: add color variants for monsters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Torches now cast light, revealing nearby tiles for increased visibility.
 - Subtle floor and wall color variations between floors for greater variety.
 - Griffin, dragon, and snake boss variants.
+- Red, blue, and yellow slime variants with unique stats, plus new mage and bat color schemes.
 
 ### Changed
 - Recombined CSS and JavaScript into `index.html` to maintain a single-file distribution.

--- a/index.html
+++ b/index.html
@@ -305,12 +305,33 @@ function genSprites(){
     px(g,9,11,2,2,'#134013'); px(g,13,11,2,2,'#134013');
     outline(g,S);
   });
+  SPRITES.slime_red = makeSprite(24,(g,S)=>{
+    px(g,4,10,16,10,'#d16f6f'); px(g,6,8,12,10,'#e27e7e'); px(g,8,6,8,8,'#f09b9b');
+    px(g,9,11,2,2,'#401313'); px(g,13,11,2,2,'#401313');
+    outline(g,S);
+  });
+  SPRITES.slime_blue = makeSprite(24,(g,S)=>{
+    px(g,4,10,16,10,'#6f7ed1'); px(g,6,8,12,10,'#7e8ee2'); px(g,8,6,8,8,'#9ba6f0');
+    px(g,9,11,2,2,'#131340'); px(g,13,11,2,2,'#131340');
+    outline(g,S);
+  });
+  SPRITES.slime_yellow = makeSprite(24,(g,S)=>{
+    px(g,4,10,16,10,'#d1d16f'); px(g,6,8,12,10,'#e2e27e'); px(g,8,6,8,8,'#f0f09b');
+    px(g,9,11,2,2,'#404013'); px(g,13,11,2,2,'#404013');
+    outline(g,S);
+  });
   // Bat 24x24
   SPRITES.bat = makeSprite(24,(g,S)=>{
     // wings
     px(g,2,12,8,6,'#20222b'); px(g,14,12,8,6,'#20222b');
     // body
     px(g,9,10,6,8,'#2e3240'); px(g,10,8,4,3,'#2e3240');
+    px(g,10,12,1,2,'#9b0000'); px(g,13,12,1,2,'#9b0000');
+    outline(g,S);
+  });
+  SPRITES.bat_brown = makeSprite(24,(g,S)=>{
+    px(g,2,12,8,6,'#3b2b1a'); px(g,14,12,8,6,'#3b2b1a');
+    px(g,9,10,6,8,'#4c3524'); px(g,10,8,4,3,'#4c3524');
     px(g,10,12,1,2,'#9b0000'); px(g,13,12,1,2,'#9b0000');
     outline(g,S);
   });
@@ -332,6 +353,20 @@ function genSprites(){
     px(g,8,2,8,4,'#e6c9a6'); px(g,9,3,2,2,'#000'); px(g,13,3,2,2,'#000');
     // staff/glow
     px(g,3,6,2,14,'#7a5cff'); px(g,2,6,4,2,'#b84aff');
+    outline(g,S);
+  });
+  SPRITES.mage_red = makeSprite(24,(g,S)=>{
+    px(g,6,8,12,10,'#7e3a3a'); px(g,8,6,8,3,'#7e3a3a');
+    px(g,6,16,12,2,'#ff4a4a');
+    px(g,8,2,8,4,'#e6c9a6'); px(g,9,3,2,2,'#000'); px(g,13,3,2,2,'#000');
+    px(g,3,6,2,14,'#ff5c5c'); px(g,2,6,4,2,'#ffb84a');
+    outline(g,S);
+  });
+  SPRITES.mage_green = makeSprite(24,(g,S)=>{
+    px(g,6,8,12,10,'#3a7e4a'); px(g,8,6,8,3,'#3a7e4a');
+    px(g,6,16,12,2,'#4aff5c');
+    px(g,8,2,8,4,'#e6c9a6'); px(g,9,3,2,2,'#000'); px(g,13,3,2,2,'#000');
+    px(g,3,6,2,14,'#5cff7a'); px(g,2,6,4,2,'#4aff5c');
     outline(g,S);
   });
 
@@ -709,12 +744,30 @@ function scaleStat(base, perFloor){ return Math.max(1, Math.floor(base + perFloo
 function spawnMonster(type,x,y){
   // Base stats per archetype
   const archetypes = [
-    { hp:18, dmg:[2,4], atkCD:28, moveCD:[6,10] },    // slime: sturdy melee, high HP
+    { hp:18, dmg:[2,4], atkCD:28, moveCD:[6,10] },    // slime base
     { hp:6,  dmg:[1,3], atkCD:22, moveCD:[4,8] },     // bat: frail but fast
     { hp:14, dmg:[2,5], atkCD:38, moveCD:[6,10] },    // skeleton: durable ranged
     { hp:11, dmg:[3,7], atkCD:39, moveCD:[6,10] },    // mage: higher damage, slower attack
   ];
-  const a = archetypes[type] || archetypes[0];
+  let a = archetypes[type] || archetypes[0];
+  let spriteKey;
+  if(type===0){ // slime variants
+    const vars = [
+      {key:'slime', hp:18, dmg:[2,4], atkCD:28, moveCD:[6,10]},
+      {key:'slime_red', hp:16, dmg:[3,6], atkCD:28, moveCD:[6,10]},
+      {key:'slime_blue', hp:14, dmg:[2,4], atkCD:24, moveCD:[4,8]},
+      {key:'slime_yellow', hp:24, dmg:[2,5], atkCD:32, moveCD:[8,12]},
+    ];
+    const v = vars[rng.int(0, vars.length-1)];
+    a = {hp:v.hp, dmg:v.dmg, atkCD:v.atkCD, moveCD:v.moveCD};
+    spriteKey = v.key;
+  } else if(type===1){ // bat variants
+    const vars = ['bat','bat_brown'];
+    spriteKey = vars[rng.int(0, vars.length-1)];
+  } else if(type===3){ // mage variants
+    const vars = ['mage','mage_red','mage_green'];
+    spriteKey = vars[rng.int(0, vars.length-1)];
+  }
   const diff = 1 + SCALE.HARDNESS_MULT * Math.max(0, floorNum-1);
   const m = {
     x, y, rx:x, ry:y, type,
@@ -733,6 +786,7 @@ function spawnMonster(type,x,y){
   m.resIce = elemRes;
   m.resShock = elemRes;
   m.resMagic = magicRes;
+  if(spriteKey) m.spriteKey = spriteKey;
   return m;
 }
 


### PR DESCRIPTION
## Summary
- add red, blue, and yellow slime sprites with variant stats
- include new mage and bat color schemes
- randomize monster spawning to pick variant sprites and slime attributes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae70b7fedc8322a4eca742e55c8a4e