### PR TITLE
Animate idle sprites for slime variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Griffin, dragon, and snake boss variants.
 - Red, blue, and yellow slime variants with unique stats, plus new mage and bat color schemes.
 - Animated dragon boss idle sprite sheet and generic frame-based monster animation.
+- Idle animation sprite sheets for red, yellow, and green slime variants.
 
 ### Changed
 - Recombined CSS and JavaScript into `index.html` to maintain a single-file distribution.

--- a/index.html
+++ b/index.html
@@ -299,25 +299,38 @@ function genSprites(){
     outline(g,S);
   });
 
-  // Slime 24x24
-  SPRITES.slime = makeSprite(24,(g,S)=>{
-    px(g,4,10,16,10,'#6fd16f'); px(g,6,8,12,10,'#7ee27e'); px(g,8,6,8,8,'#9bf09b');
-    px(g,9,11,2,2,'#134013'); px(g,13,11,2,2,'#134013');
-    outline(g,S);
-  });
-  SPRITES.slime_red = makeSprite(24,(g,S)=>{
-    px(g,4,10,16,10,'#d16f6f'); px(g,6,8,12,10,'#e27e7e'); px(g,8,6,8,8,'#f09b9b');
-    px(g,9,11,2,2,'#401313'); px(g,13,11,2,2,'#401313');
-    outline(g,S);
-  });
+  // Slime idle animations 24x24
+  function loadSlimeSprite(key, src){
+    const blank = document.createElement('canvas');
+    blank.width = blank.height = 24;
+    SPRITES[key] = { cv: blank, frames: [] };
+    const img = new Image();
+    img.src = src;
+    img.onload = () => {
+      const fw = img.width / 2;
+      const fh = img.height / 2;
+      for(let row=0; row<2; row++){
+        for(let col=0; col<2; col++){
+          const c = document.createElement('canvas');
+          c.width = c.height = 24;
+          const g = c.getContext('2d');
+          g.imageSmoothingEnabled = false;
+          g.drawImage(img, col*fw, row*fh, fw, fh, 0, 0, 24, 24);
+          SPRITES[key].frames.push(c);
+        }
+      }
+      if(SPRITES[key].frames.length){
+        SPRITES[key].cv = SPRITES[key].frames[0];
+      }
+    };
+  }
+  loadSlimeSprite('slime', 'slime_green_idle.png');
+  loadSlimeSprite('slime_red', 'slime_red_idle.png');
+  loadSlimeSprite('slime_yellow', 'slime_yellow_idle.png');
+  // Blue slime remains static
   SPRITES.slime_blue = makeSprite(24,(g,S)=>{
     px(g,4,10,16,10,'#6f7ed1'); px(g,6,8,12,10,'#7e8ee2'); px(g,8,6,8,8,'#9ba6f0');
     px(g,9,11,2,2,'#131340'); px(g,13,11,2,2,'#131340');
-    outline(g,S);
-  });
-  SPRITES.slime_yellow = makeSprite(24,(g,S)=>{
-    px(g,4,10,16,10,'#d1d16f'); px(g,6,8,12,10,'#e2e27e'); px(g,8,6,8,8,'#f0f09b');
-    px(g,9,11,2,2,'#404013'); px(g,13,11,2,2,'#404013');
     outline(g,S);
   });
   // Bat 24x24


### PR DESCRIPTION
## Summary
- slice red, yellow, and green slime idle sheets into animation frames
- keep blue slime as existing static sprite
- document new animated slime sheets in changelog
- remove idle sprite sheet PNG files from version control

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae788498688322adc9dd99f8e26ab9