### PR TITLE
feat: add snake boss idle animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Griffin, dragon, and snake boss variants.
 - Red, blue, and yellow slime variants with unique stats, plus new mage and bat color schemes.
 - Animated dragon boss idle sprite sheet and generic frame-based monster animation.
+- Animated snake boss idle sprite sheet.
 
 ### Changed
 - Recombined CSS and JavaScript into `index.html` to maintain a single-file distribution.

--- a/index.html
+++ b/index.html
@@ -407,15 +407,31 @@ function genSprites(){
       }
     };
   }
-  SPRITES.snake = makeSprite(48,(g,S)=>{
-    // body
-    px(g,8,28,32,8,'#3a8');
-    // neck
-    px(g,20,16,8,12,'#3a8');
-    // head
-    px(g,16,12,16,8,'#3a8');
-    outline(g,S);
-  });
+  // Snake boss: load idle animation sheet and slice into frames
+  {
+    const blank = document.createElement('canvas');
+    blank.width = blank.height = 48;
+    SPRITES.snake = { cv: blank, frames: [] };
+    const img = new Image();
+    img.src = 'snake_idle.png';
+    img.onload = () => {
+      const fw = img.width / 2;
+      const fh = img.height / 2;
+      for (let row = 0; row < 2; row++) {
+        for (let col = 0; col < 2; col++) {
+          const c = document.createElement('canvas');
+          c.width = c.height = 48;
+          const g = c.getContext('2d');
+          g.imageSmoothingEnabled = false;
+          g.drawImage(img, col * fw, row * fh, fw, fh, 0, 0, 48, 48);
+          SPRITES.snake.frames.push(c);
+        }
+      }
+      if (SPRITES.snake.frames.length) {
+        SPRITES.snake.cv = SPRITES.snake.frames[0];
+      }
+    };
+  }
 
   // Stairs (down) 24x24
   SPRITES.stairs = makeSprite(24,(g,S)=>{


### PR DESCRIPTION
## Summary
- animate snake boss using new four-frame idle sheet
- document snake idle sprite in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7aaf10748322ba1482ca2484ec64