### PR TITLE
fix: remove blue slime and restore slime animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Torches now cast light, revealing nearby tiles for increased visibility.
 - Subtle floor and wall color variations between floors for greater variety.
 - Griffin, dragon, and snake boss variants.
-- Red, blue, and yellow slime variants with unique stats, plus new mage and bat color schemes.
+- Red and yellow slime variants with unique stats, plus new mage and bat color schemes.
 - Animated dragon boss idle sprite sheet and generic frame-based monster animation.
 - Idle animation sprite sheets for red, yellow, and green slime variants.
 
@@ -49,7 +49,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 
 - Weapon damage and armor/resistance values now scale with item level and rarity. Player base resistances increase slightly each level.
 
+### Removed
+- Blue slime enemy variant.
+
 ### Fixed
+- Slime idle animations now render without missing image assets.
 - Melee attacks now track the mouse and register hits within a 35° cone (2-tile reach by default).
 - Warrior class no longer registers as a mage.
 - Warrior skill menu now displays ability descriptions.

--- a/index.html
+++ b/index.html
@@ -300,39 +300,27 @@ function genSprites(){
   });
 
   // Slime idle animations 24x24
-  function loadSlimeSprite(key, src){
-    const blank = document.createElement('canvas');
-    blank.width = blank.height = 24;
-    SPRITES[key] = { cv: blank, frames: [] };
-    const img = new Image();
-    img.src = src;
-    img.onload = () => {
-      const fw = img.width / 2;
-      const fh = img.height / 2;
-      for(let row=0; row<2; row++){
-        for(let col=0; col<2; col++){
-          const c = document.createElement('canvas');
-          c.width = c.height = 24;
-          const g = c.getContext('2d');
-          g.imageSmoothingEnabled = false;
-          g.drawImage(img, col*fw, row*fh, fw, fh, 0, 0, 24, 24);
-          SPRITES[key].frames.push(c);
-        }
-      }
-      if(SPRITES[key].frames.length){
-        SPRITES[key].cv = SPRITES[key].frames[0];
-      }
-    };
+  function makeSlimeAnim(c1, c2, c3){
+    const frames = [];
+    for(let i=0;i<4;i++){
+      const c=document.createElement('canvas');
+      c.width=c.height=24;
+      const g=c.getContext('2d');
+      g.imageSmoothingEnabled=false;
+      const bob = (i%2===0)?0:1;
+      px(g,4,10+bob,16,10-bob,c1);
+      px(g,6,8+bob,12,10-bob,c2);
+      px(g,8,6+bob,8,8,c3);
+      px(g,9,11+bob,2,2,'#131340');
+      px(g,13,11+bob,2,2,'#131340');
+      outline(g,24);
+      frames.push(c);
+    }
+    return { cv: frames[0], frames };
   }
-  loadSlimeSprite('slime', 'slime_green_idle.png');
-  loadSlimeSprite('slime_red', 'slime_red_idle.png');
-  loadSlimeSprite('slime_yellow', 'slime_yellow_idle.png');
-  // Blue slime remains static
-  SPRITES.slime_blue = makeSprite(24,(g,S)=>{
-    px(g,4,10,16,10,'#6f7ed1'); px(g,6,8,12,10,'#7e8ee2'); px(g,8,6,8,8,'#9ba6f0');
-    px(g,9,11,2,2,'#131340'); px(g,13,11,2,2,'#131340');
-    outline(g,S);
-  });
+  SPRITES.slime = makeSlimeAnim('#5ca94a','#6bbd59','#8ed97b');
+  SPRITES.slime_red = makeSlimeAnim('#d35e5e','#e06e6e','#f18b8b');
+  SPRITES.slime_yellow = makeSlimeAnim('#d3c85e','#e0d56e','#f1e58b');
   // Bat 24x24
   SPRITES.bat = makeSprite(24,(g,S)=>{
     // wings
@@ -784,7 +772,6 @@ function spawnMonster(type,x,y){
     const vars = [
       {key:'slime', hp:18, dmg:[2,4], atkCD:28, moveCD:[6,10]},
       {key:'slime_red', hp:16, dmg:[3,6], atkCD:28, moveCD:[6,10]},
-      {key:'slime_blue', hp:14, dmg:[2,4], atkCD:24, moveCD:[4,8]},
       {key:'slime_yellow', hp:24, dmg:[2,5], atkCD:32, moveCD:[8,12]},
     ];
     const v = vars[rng.int(0, vars.length-1)];


### PR DESCRIPTION
## Summary
- remove unused blue slime variant and sprite
- inline green, red, and yellow slime animations without external assets
- document blue slime removal and animation fix in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7b75af548322a620902253e7ef0e