### PR TITLE
feat: animate skeleton mage sprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Reduced wizard spawn chance on lower floors.
 - Increased potion drop rate to 40% (from 25%).
 - Mage enemies now fire 30% slower but hit 10% harder.
+- Mage enemies now use an animated skeleton sprite with purple energy.
 - Enemy elemental resistances now scale with floor level.
 - Mini bosses now always drop gold and may also drop gear or weapons.
 - Warrior abilities now unlock sequentially on the skill tree and bind to Q instead of using modifier keys.

--- a/index.html
+++ b/index.html
@@ -344,31 +344,41 @@ function genSprites(){
     outline(g,S);
   });
 
-  // Mage/Cultist 24x24 (caster enemy)
-  function makeMageAnim(robe, trim, staff, glow){
+  // Skeleton Mage 24x24 (caster enemy)
+  function makeMageAnim(){
     const frames = [];
+    const orbYOffset = [0,-1,0,1];
     for(let i=0;i<4;i++){
       const c=document.createElement('canvas');
       c.width=c.height=24;
       const g=c.getContext('2d');
       g.imageSmoothingEnabled=false;
       const bob = (i%2===0)?0:1;
-      // robe
-      px(g,6,8+bob,12,10,robe); px(g,8,6+bob,8,3,robe);
-      // trim
-      px(g,6,16+bob,12,2,trim);
-      // head
-      px(g,8,2+bob,8,4,'#e6c9a6'); px(g,9,3+bob,2,2,'#000'); px(g,13,3+bob,2,2,'#000');
-      // staff/glow
-      px(g,3,6+bob,2,14,staff); px(g,2,6+bob,4,2,glow);
+      // skull
+      px(g,7,2+bob,10,6,'#e9edf1');
+      px(g,9,4+bob,2,2,'#7e4ab8');
+      px(g,13,4+bob,2,2,'#7e4ab8');
+      // body
+      px(g,8,10+bob,8,6,'#dde3ea');
+      px(g,6,10+bob,2,4,'#dde3ea');
+      px(g,16,10+bob,2,4,'#dde3ea');
+      px(g,8,18+bob,3,3,'#dde3ea');
+      px(g,13,18+bob,3,3,'#dde3ea');
+      // casting arm
+      px(g,18,10+bob,4,2,'#dde3ea');
+      // purple orb
+      const oy = 5 + orbYOffset[i];
+      px(g,21,oy+bob,2,2,'#b84aff');
+      px(g,22,oy-1+bob,1,1,'#d9a3ff');
+      px(g,23,oy-2+bob,1,1,'#d9a3ff');
       outline(g,24);
       frames.push(c);
     }
     return { cv: frames[0], frames };
   }
-  SPRITES.mage = makeMageAnim('#4a3a7e','#b84aff','#7a5cff','#b84aff');
-  SPRITES.mage_red = makeMageAnim('#7e3a3a','#ff4a4a','#ff5c5c','#ffb84a');
-  SPRITES.mage_green = makeMageAnim('#3a7e4a','#4aff5c','#5cff7a','#4aff5c');
+  SPRITES.mage = makeMageAnim();
+  SPRITES.mage_red = makeMageAnim();
+  SPRITES.mage_green = makeMageAnim();
 
   // Boss variants 48x48
   SPRITES.griffin = makeSprite(48,(g,S)=>{


### PR DESCRIPTION
## Summary
- animate mage enemies with a skeleton sprite and purple energy orb
- document skeleton mage visuals in changelog

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae802881d483229d53b208a8a3b151