### PR TITLE
Add animated griffin sprite

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,17 +381,28 @@ function genSprites(){
   SPRITES.mage_green = makeMageAnim();
 
   // Boss variants 48x48
-  SPRITES.griffin = makeSprite(48,(g,S)=>{
-    // wings
-    px(g,6,18,36,12,'#b88f4a');
-    // body
-    px(g,16,24,16,16,'#c8a14a');
-    // head
-    px(g,20,12,8,8,'#e0c272');
-    // legs
-    px(g,18,40,4,8,'#8c6239'); px(g,26,40,4,8,'#8c6239');
-    outline(g,S);
-  });
+  // Griffin boss: image-based with simple bobbing animation
+  {
+    const blank = document.createElement('canvas');
+    blank.width = blank.height = 48;
+    SPRITES.griffin = { cv: blank, frames: [] };
+    const img = new Image();
+    img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQfpCBsEBBg6/o47AAARh0lEQVRYw015S48lyXXed05E5PM+6956dvVz2JxuTvM1tEQMSEmASEAQBAOCAW3kjQUY8G/wX/DKS2+8sAl44YU3BAzYkPUcSx6QokYkh9TMqKdnqrq7qqurbt33zcyIOMeLvNWjvHETuciMPHnOie+c7wt6eJgZZms5cSa1JnEmdcZZYw0bQ8zERARFe6iKQlRj1CjboQKFEsAEw8RM7ZmJFBBFiBKi+ig+xMZLE2LjYxPEB/Eh+ighSogiAhFYvpnCMLfXxERERCC6uQBhaxMRQAAxGKQqSlCGAq1B7QzMZAwzQRVQGGVRMUqR2bAyM7Ma1tjerMRCzKSqxLDWsDFsjbGGnf3SN4bZGmYmxtYBAAEwgCg4qocATKSqAJQITO2HvXESVMkoPES3/oWqCqCqeuNsUaiBAlAhVdta4KxJ3HY4w9YwAcFHIhimNDGtv0S0akI7vTMsrCKqCgJag5gQRZ1hZ4mJmiAhirPcerv9JAIB0DfjjbEgEtg0MYY5cSZ1NrHM7XOqdRNeT1aW4Zw53O0CSkR1E19eLJhgrRntdKCwht+8yjCpyouL+f5O2RlkzvHV+fp60RztdaHa3tmGtU0EJiKK7ccQQJEiiU2dMYYTa/LM+iZOpitjiKBRUKZ0b8jLRk/PZwyAoIrE0u0Bb7yevZ5DsTfq5JkDtm+SCMt0frXMEj0ad5ipCeHFxTyKjoelNW0aMFNsk7VNSLSWEbGQTZ01hhPLeWp8E8c9+uPfLX2AKlKHy+v4pz9dP97jbsn/4km+XMn7H27OZrLfo3tD9lFfXC0Oxt1umarCMinRptZ//293P/jF6qNPZg/vdAzj7HLdSWg2X/sg/W7e72Y1E7N8uWhoG/EoZB7f6TnLSWKc4V7hFPTi1eaoAwM93HVlwV+5ndzZs5tVDI0+uJ3ev+XuHtizizBdqwKDjCaLho3pFkkT4udnMx/kvQf8B9/vnV6Hv/zprPahqqMP6gNE4EM0rL0yU4B4G6t2IROBmekPv3fbGHLWOMtFwpZxcbmeTJZsaH9g3jliVXQ65u5RMl/GZ6dNktC33ymu53G6lJ/8cn02h2NdexoOyvGguJquX14uywR/8sPi8aPOxYbSNCvHR97HzfULbFb/488X/+sn9fF+eeeot6xi7aVqQt3E2gcfYhQ179wbGEPtUtpsms+fz8d9/uG76e09d7xr93asMbia+Kj04G7GTGXBy2VILG7tJ4MO/+ILnxkqEp2vPbHZGxZ5aq/m4Wef1k7i12/xMJNBGr76dnL/0eGtg8G9u7vvPi4Hdv6Tj/3+qCQibX1DREyGyTKDGYbBpFlqEscnrzaPjrJv37NRwJbKW8nFjn01CT//9fpgZNhBlefzoIr9sXOWrjdy0GNIXFVh2NWqDnXQe2PDPizWalL96f959ux/l4GLf/UvH77z3cN33hm9eFQ0zdOffbEuyjLPmGgLXVHU8g0iq2qncG/d6T49Wbz/UTw9a6BIU+71XSenQcabKtaNGEN5xsaQiPqgqvAR6wZBkRMM08nF+s6Ifu+JffxWtnu3kzruDPNP/3r5KgyjmYTV4rDvXp7H3Ibzi8Xbb+8YiapgImYWEfPkXr9FP2uICNbyqJ9Y1nkt60DzCmeTeHEVcpKv3s96XZulvFwGBQ72MgF+8nGdEATwQt0iFZWu8z98bI737O7t7mBUkOHjW8mjfQ39b/3F+5/j+rOkWv7XH09/9nr31u3bvvHOOaIt1hOR1TdIqVCFYbqah8Wi+pPf66QWTHAJ17U8O6l++fFmd8jO0a2jfHJd+yAt8oJQeRn2y0E3+dWzyb9+L9msAxdlpyCy3d6wV03PDx7gV//zT79zoA+H6QefF09l7/Hbh+/+xnd+9J//07BXFBm3IQPIfO1en9sQGjKGidArHMj81YeLDstiLS4xTdBez+6N3cvzJgh2R0mS8nTqk8T89J88RKMgz1wnd5NF/eFJeHLX9W3T3T/Yv30QghiXSrP+3teL24P4/06Hf/f6qJfRdL44/eIkL7svnp9Yo1lqJQoAC7zpLdrqR1Ex6KUxdn78szkbFqkVGOT43kP35HEZo15cVNu6DzBBbh51lh8e9z78dDY+yAZdT2QWk8n07OVwr0OGTz+e/uiv8cFZNPwSqs6ag1FfNapKWxFbULLbnAYBpCDZ/mlnkM9W0debP/qtcl1rYik1+sln1ZNHeZqkVaOzqVfFptbgoQRmNEGenS3+ze84XVQyyvYOS1XJcoTGTy7Wvb7rZVVaTyKTRAlMl2G+Mz4QVdVtnSWoeXJ/wNS2L3xTsUkVBOoWTkR94x8fmZRVoi4W8cVFvLwOEI1Rez13NDafnYfpMo77aadIoDpbh7fuJg8fdKKv2bpyMAh1lQ32QlP7+eZqUgvx8Tjr5TZ1NFssB52kWzgmtHaZb9wb8k1rllpzOd2cnC+X69DNnTGcJu6zl82np9Wvn8ePTsPFXEMt946SXtfUtYQgX7mV7A/N1Uwupr5IzdGo+LOfL37wXm+v1Frc6HCPjAmbRf/g+PzkYrenLxf0q5Ow03PjnbJbpqRxNMidY1FRVYKab9zfMUTWsApeXizni1qbJjRh5bVXJM5yp3Qnl3G6CodDzhI62jFZZuZLuZwEJq1q/cpx8vGL8OysAeTVdfOb9+ndR7kl6e3tDvbGEoWNMy63iXMmJNJcTsOzi/DgqABRt5MRfdm0ATDfeLDTghITZsuqqnzujCOlEKqgWWpTa5ylerN5774dlSDg4tIbqHXULUxVxzQ1eUaXM72ahffept//VrK/l7jcdgY9JsSmSspBs5z0D/Zgk71ePOjKfB6may0Lp9vmETeZBPPNe6MWqa0x3SLZ1GHTxHFGOymez+PesCBQCLKuw+U8XMxxNtWVh0m4TKmqpchZQY/uJmXOTDjo89MLKVPqZOjvjZhCNb/O+zv1auY3q3Iw5MSWusgMfvzB8sFxR0F6c4gqoOYb94ZtLgOwTNbyalXt5aTA3IMNZ4nNE5ul9vnEX62kk1MTMV1KL6XpXACQaNXoW0fuyYP0L37ZPHsezs/rO7eSIrPzWW0pNsF0R3t+NRNft69uYlyscb2IibOAim7ZC6Dm63eHN8UWzByCzNbN2mtpsfY6q+JuPyfAGR6UiW/qRwc07tBOh8qOeTWV4MVZ0iiqSBPz29/Me1X4hy9COXSnH0+m0+rebff80/NyUHR3D5vVxFib9ndls4yN//O/X+7u5GQoioq0UYMVEYCFlJlUtJMnh6Pu81fT62bLhLYYAaTOHI66f/N0LgoRLRJxBj94x766CiEaH/1kGvRuPl/Ld4/N6UerV7P4/e9nk7ksVvr6ixO2TgTS+J1hIYO7/+3P/paZibRt9BXbdDJP7vSZQFuOB8MUgsyWdRQAYGPHvawlO1UdRXVYujKzjQ/vvWVu77CC5itdbeTlZby6jtfnPjbay2m3Q7tdPj+r3/9g+eyF/843u69PLkSiZV9tmtEgezhe/dXPq/EgZaKo2jpJAXuDkwpVAkHRzd3dvfLictGQfbDXBQiK2bI+ebVgvmEwqu9/EgkwhCbieIBRRsu1ntXyaJdTCwBlQoWjjpWzSl5PQwadnK8kZP2d5er1os1auqnr0PanFlvauT2socXav3i9LA1qgTNsiObr6uXF4mt9DHIVxcbDC6JCRA9K+vsrfDaBL3WQbCdS3VY6Yuz2OM/0P/yX1//uD/tZ8AIajrJNFS4vKmzDhZY0qkIUbciImaxp6SaXHDtx/ao2x7vdMrWzdf36av6tEe4OaafgxOCLmVYBmQETvCBl9BPkDMsYZDSvkVk4Q/0OsgR1g9TSQUn/91d1v2/HHYo+TmrzH//7ZNPoeJgryEeNUYNoFOUtTyMAZA2vNs3Hz6crj6DoF8l846+u5l8f6N0B5Y4MIzFUWDQR0xpBUEU4RmlhGVGwqFvVgUSROFiDNhd3S5pNYwBXdZxc+drr1ULvHvUADlGjaBCNUWNUfhMuw3S9rC8vp7eyeF6be3sdAkIUFRlkLWnHqAPLeGvIt7p0VtFVBShEEQQAguLTObSlp4TrOWLEuA8f9WwmQUGkxHQ9qU//aWYM8sxGhY8abkYUtW3kRKGAj1L7qA6RqJMlAKAgovYro2DdYKeLUYfqCH+JOuq80cKRIQTBrMYykI8gwrqBKDo5nEUd8HSivQ69Om/2Mns+jX/5j/54vwwChYSoPkgIEqKKqI0CkIpqaGUDQlS0vjFk2m5XBOsGmaNNrbs9atdnECxBhlRUmQCFFyiol6L2OqtQJqga2tRYbPTVUu8fUGHk16f+707kdIJvvp1VXn2QJogP6qOGIK1BomBCqz7BMXUTxBVSw5UPl7ONCJ0ucUwqiiLBZKnDDh318aCLzxY0pG3IFFhHGiVqiJY1nEGe0HSlZwt8OsOdXbo94os1ffhcpmu6NU43jURRH9UH8UFCFB9FRM3Dw462YgpTE+J63fQsouK61sW6Jl9vIjWCgxxBkDtqAgjkDMHrswUFoUaJoVCdRb6VaeVhGKOCiwSbRp8v8Os5/c5XzYsZ/fx5nCxl0HV7o9JHDdLKahJuzlHUPNgvAVDL1YCqiTHEW7lerT1LZKKgdFygn7T6GaWOvNfXc3wypYsKCloLOWcSa5Zeo8KQ9hPKHaLgbIkvllhGYuCjlyIRRcpJ6rLURkWIGqKEIDeqnsao5u5uoTcte5LYLHXTTRCRjqOE0SgdFHirBxCYIAIQThb4fKYfz8gQdhKto5advNstNk2cNmCiwiKz1AT9xQRPl1QafTnTnRSroGmRHewUPuo2XlFuQqY+SBS1PspWcCOgQWpNv1+cXa9DTV0TvztWIqoiqog6ggnrhf7DNRFoL1NRNAJuFSim/Z0iXq0uGnErOehhmKOYI1mjtDrKYA1RA9UWALHVTG9We+ueqGp9EDH4UhUBWebj3e6mDov56vVGOw4CfDLFpefWlQeZAvAKUcw8jfp5J0+CgI053ClPL5eZRZphf0zDuTaXmAUm0p2SZs0btgNVahFHFVEgN5ou+yhN2Iq0TZQYJeoNrQU6CR33qIpYqPnKfuf2qGBCowiK64auGxp0syx18qYWMhPwdEEfXUAgWarOmaNRMfU0WUsLUS0YKkh0S7xuhooq+7iNn48SggQREW2zqoo6qVEktFNQK+ZZQ1F07okJw0QVuFpUmzqoIioUxMxH4y7Y9EpMlvRyopklY40ocgeGAliu6pevF1FIdTtk6ySIqBl3E2wVaCImpm1KpJZBPN/4cYZ+SvNKP7tuVlUc9bL5Jnih0iFhVAGbJs5WtQJF5hTknL1a1InGJ8eUOXz2SiarxkcsGr03JFL54tpDZFmFJE0F8PFmlYmIwux07Lb/IOKtrkYEOGtEUW2aOx3eG9DhEFb0/lhPZ8hSt6yDF+o45BZVRM9p8NHDlHl6cj779mE47gLAw30cjZKT9fjd/fWF700qGqVNN0+uaJzmxXq5sMbEKD7EECW2wDgsTdsRtWJt24owExOcIVVdbnxudVrpyRwdp08nOh4WIF5WISq8oI4gQhMEzOvKLyUjDa8XYbHR0uiixkdn6kNzq6vXqzCtNCrWHiQ+NpVLXIgS/rlB/bxVfN9sJBAzmEBA6jhNTA0iY6+8XYpTY8m4NLWJM6oKY4Q5cZaMcYktUgdIp1PUEbVykbsA93rNQWMNu9dV58xGXABnJhiNxlkiCiFuPSQiKnRn7Fpu7wwnziSWU2dTx5kzqePUcpFyu1tAgBcEQdWIv9l8UVWADLctOTvLluEspRbWbp8KUUS1DuSjNl6aoD4iCHzQqglV4+smND76EKOIFVEQiESIYpRIiBwjIxCYlFRVxZnt1g6AcLMcQpB40yCIQJms1RAUhhRQJStkDKBokVBUfNDtiBqiNtuuQ2LrHhERsdpy/BsYEFURFZEoFKNGEiMcCUpbJb/lQCJvCGcL8nSza/GGMUAVIvTlnotsLwDFP3tRe6hsp/z/voC13bRSIukAAAAASUVORK5CYII=';
+    img.onload = () => {
+      const bob = [0,1,0,-1];
+      for (const y of bob) {
+        const c = document.createElement('canvas');
+        c.width = c.height = 48;
+        const g = c.getContext('2d');
+        g.imageSmoothingEnabled = false;
+        g.drawImage(img, 0, y);
+        SPRITES.griffin.frames.push(c);
+      }
+      if (SPRITES.griffin.frames.length) {
+        SPRITES.griffin.cv = SPRITES.griffin.frames[0];
+      }
+    };
+  }
   // Dragon boss: simple idle animation generated in code
   function makeDragonAnim(){
     const frames = [];


### PR DESCRIPTION
## Summary
- Replace placeholder griffin boss sprite with image-based version
- Add simple bobbing animation frames for the griffin boss

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae835ca8d48322a84689f59a776734