### PR TITLE
Add dragon hatchling mob and update dragon boss sprite

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,7 +414,29 @@ function genSprites(){
     return { cv: frames[0], frames };
   }
   SPRITES.griffin = makeBossAnim("#c49a6b","#e0cc91");
-  SPRITES.dragon = makeBossAnim("#5c8a4a","#8ed97b");
+
+  const dragonImg = new Image();
+  dragonImg.src = 'data:image/png;base64,' +
+    'iVBORw0KGgoAAAANSUhEUgAAAwcAAANbCAYAAAAXFOPDAAABamlDQ1BJQ0MgUHJvZmlsZQAAeJx1kL1Lw1AUxU+rUtA6iA4dHDKJ' +
+    'Q9TSCnZxaCsURTBUBatTmn4JbXwkKVJxE1cp+B9YwVlwsIhUcHFwEEQHEd2cOim4aHjel1TaIt7H5f04nHO5XMAbUBkr9gIo6ZaR' +
+    'TMSktdS65HuDh55TqmayqKIsCv79u+vz0fXeT4hZTbt2ENlPXJfOLpd2ngJTf/1d1Z/Jmhr939RBjRkW4JGJlW2LCd4lHjFoKeKq' +
+    '4LzLx4LTLp87npVknPiWWNIKaoa4SSynO/R8B5eKZa21g9jen9VXl8Uc6lHMYRMmGIpQUYEEBeF//NOOP44tcldgUC6PAizKREkR' +
+    'E7LE89ChYRIycQhB6pC4c+t+D637yW1t7xWYbXDOL9raQgM4naGT1dvaeAQYGgBu6kw1VEfqofbmcsD7CTCYAobvKLNh5sIhd3t/';
+  const dragonCanvas = document.createElement('canvas');
+  dragonCanvas.width = dragonCanvas.height = 48;
+  const dragonCtx = dragonCanvas.getContext('2d');
+  dragonCtx.imageSmoothingEnabled = false;
+  const hatchCanvas = document.createElement('canvas');
+  hatchCanvas.width = hatchCanvas.height = 24;
+  const hatchCtx = hatchCanvas.getContext('2d');
+  hatchCtx.imageSmoothingEnabled = false;
+  dragonImg.onload = () => {
+    dragonCtx.drawImage(dragonImg, 0, 0, 48, 48);
+    hatchCtx.drawImage(dragonImg, 0, 0, 24, 24);
+  };
+  SPRITES.dragon = { cv: dragonCanvas, frames: [dragonCanvas] };
+  SPRITES.dragon_hatchling = { cv: hatchCanvas, frames: [hatchCanvas] };
+
   SPRITES.snake = makeBossAnim("#8a5c8a","#d98bff");
 
 
@@ -696,9 +718,9 @@ function generate(){
         // reduce mage frequency on early floors
         t = rng.next() < 0.1 ? 3 : rng.int(0,2);
       } else {
-        t = rng.int(0,3);
+        t = rng.int(0,4);
       }
-      // 0=slime, 1=bat, 2=skeleton, 3=mage
+      // 0=slime, 1=bat, 2=skeleton, 3=mage, 4=dragon hatchling
       monsters.push(spawnMonster(t,x,y));
       placed=true;
     }
@@ -778,6 +800,7 @@ function spawnMonster(type,x,y){
     { hp:6,  dmg:[1,3], atkCD:22, moveCD:[4,8] },     // bat: frail but fast
     { hp:14, dmg:[2,5], atkCD:38, moveCD:[6,10] },    // skeleton: durable ranged
     { hp:11, dmg:[3,7], atkCD:39, moveCD:[6,10] },    // mage: higher damage, slower attack
+    { hp:12, dmg:[3,6], atkCD:30, moveCD:[6,10] },    // dragon hatchling
   ];
   let a = archetypes[type] || archetypes[0];
   let spriteKey;
@@ -796,6 +819,8 @@ function spawnMonster(type,x,y){
   } else if(type===3){ // mage variants
     const vars = ['mage','mage_red','mage_green'];
     spriteKey = vars[rng.int(0, vars.length-1)];
+  } else if(type===4){ // dragon hatchling
+    spriteKey = 'dragon_hatchling';
   }
   const diff = 1 + SCALE.HARDNESS_MULT * Math.max(0, floorNum-1);
   const m = {


### PR DESCRIPTION
## Summary
- replace dragon miniboss sprite with provided base64 art and generate 24px hatchling variant
- introduce Dragon hatchling mob type and include it in monster spawning

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9d93bd2c8322b140bc05d62bed70