### PR TITLE
Add varied combat sounds and rotating level music

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An offline HTML5 dungeon crawler with inline sprites, now featuring class selection, a warrior skill tree, consumable potions and legendary gear.
 
+Recent updates add varied combat sound effects and multiple music tracks that rotate every floor.
+
 ## Play the Game
 Open `index.html` in your browser.  
 For full functionality, serve the directory with a local server:

--- a/index.html
+++ b/index.html
@@ -581,7 +581,12 @@ function updateScoreUI(){
 }
 
 // ===== Audio =====
-let audioCtx, musicTimer;
+let audioCtx, musicTimer, musicOsc, currentMusic=-1;
+const musicPacks = [
+  { type:'sine', notes:[130.81,146.83,155.56,174.61,196,207.65,233.08] },
+  { type:'square', notes:[196,220,246.94,261.63,293.66,329.63,349.23] },
+  { type:'triangle', notes:[233.08,261.63,277.18,311.13,349.23,392,415.3] }
+];
 function initAudio(){
   if(!audioCtx) audioCtx = new (window.AudioContext||window.webkitAudioContext)();
   if(audioCtx.state === 'suspended') audioCtx.resume();
@@ -598,41 +603,62 @@ function playFootstep(){
   osc.connect(gain).connect(audioCtx.destination);
   osc.start(); osc.stop(audioCtx.currentTime + 0.25);
 }
+const attackSounds=[
+  {type:'sawtooth',freq:300},
+  {type:'square',freq:260},
+  {type:'triangle',freq:320}
+];
 function playAttack(){
   initAudio(); if(!audioCtx) return;
+  const variant = attackSounds[Math.floor(Math.random()*attackSounds.length)];
   const osc = audioCtx.createOscillator();
   const gain = audioCtx.createGain();
-  osc.type = 'sawtooth';
-  osc.frequency.setValueAtTime(300, audioCtx.currentTime);
+  osc.type = variant.type;
+  osc.frequency.setValueAtTime(variant.freq, audioCtx.currentTime);
   gain.gain.setValueAtTime(0.2, audioCtx.currentTime);
   gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.15);
   osc.connect(gain).connect(audioCtx.destination);
   osc.start(); osc.stop(audioCtx.currentTime + 0.15);
 }
+const hitSounds=[
+  {type:'triangle',freq:180},
+  {type:'sine',freq:200},
+  {type:'square',freq:150}
+];
 function playHit(){
   initAudio(); if(!audioCtx) return;
+  const variant = hitSounds[Math.floor(Math.random()*hitSounds.length)];
   const osc = audioCtx.createOscillator();
   const gain = audioCtx.createGain();
-  osc.type = 'triangle';
-  osc.frequency.setValueAtTime(180, audioCtx.currentTime);
+  osc.type = variant.type;
+  osc.frequency.setValueAtTime(variant.freq, audioCtx.currentTime);
   gain.gain.setValueAtTime(0.25, audioCtx.currentTime);
   gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.2);
   osc.connect(gain).connect(audioCtx.destination);
   osc.start(); osc.stop(audioCtx.currentTime + 0.2);
 }
-function startMusic(){
-  initAudio(); if(startMusic.started) return; startMusic.started = true;
+function startMusic(packIdx){
+  initAudio(); if(!audioCtx) return;
+  if(musicTimer) clearInterval(musicTimer);
+  if(musicOsc){ try{ musicOsc.stop(); }catch(e){} }
+  const pack = musicPacks[packIdx];
   const osc = audioCtx.createOscillator();
   const gain = audioCtx.createGain();
   gain.gain.value = 0.04;
-  osc.type = 'sine';
+  osc.type = pack.type;
   osc.connect(gain).connect(audioCtx.destination);
-  const notes = [130.81,146.83,155.56,174.61,196,207.65,233.08]; // A minor
   let i = 0;
-  function next(){ osc.frequency.setValueAtTime(notes[i % notes.length], audioCtx.currentTime); i++; }
+  function next(){ osc.frequency.setValueAtTime(pack.notes[i % pack.notes.length], audioCtx.currentTime); i++; }
   next();
   musicTimer = setInterval(next, 2000);
   osc.start();
+  musicOsc = osc;
+  currentMusic = packIdx;
+}
+function nextMusic(){
+  let idx;
+  do{ idx = Math.floor(Math.random()*musicPacks.length); } while(idx===currentMusic && musicPacks.length>1);
+  startMusic(idx);
 }
 
 // --- Smooth helpers & settings ---
@@ -788,6 +814,7 @@ function generate(){
   genShopStock();
   redrawInventory();
   renderShop();
+  nextMusic();
 }
 
 // ===== Difficulty scaling & Monster factory =====
@@ -2474,7 +2501,7 @@ function loop(now){ const dt = Math.min(50, now - __last); __last = now; update(
 
 // ===== Start =====
 function startGame(){
-  initAudio(); startMusic();
+  initAudio();
   // gender pick -> sprite
   const gSel = document.querySelector('input[name="gender"]:checked');
   player.gender = (gSel?.value==='f')?'f':'m';


### PR DESCRIPTION
## Summary
- Add randomised attack and hit sound effects for richer combat audio.
- Introduce three music packs and logic to switch tracks each floor.
- Document new audio features in README.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aea351c3e48322a7d85de9c68ad19e