### PR TITLE
feat: replace dragon sprites with bone dragon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Adjusted special ability damage scaling for Mage and Warrior classes, weakening early skills and strengthening later unlocks.
 - Rebalanced loot rarity distribution to favor common and uncommon gear and increased bonuses on rare items.
 - Mini bosses and bosses now appear at twice the size of normal monsters.
+- Replaced dragon and dragon hatchling sprites with a bone dragon sporting blue flames.
 
 - Weapon damage and armor/resistance values now scale with item level and rarity. Player base resistances increase slightly each level.
 

--- a/index.html
+++ b/index.html
@@ -419,12 +419,15 @@ function genSprites(){
   SPRITES.griffin = makeBossAnim("#c49a6b","#e0cc91");
 
   const dragonImg = new Image();
+  // Bone dragon sprite with blue flames
   dragonImg.src = 'data:image/png;base64,' +
-    'iVBORw0KGgoAAAANSUhEUgAAAwcAAANbCAYAAAAXFOPDAAABamlDQ1BJQ0MgUHJvZmlsZQAAeJx1kL1Lw1AUxU+rUtA6iA4dHDKJ' +
-    'Q9TSCnZxaCsURTBUBatTmn4JbXwkKVJxE1cp+B9YwVlwsIhUcHFwEEQHEd2cOim4aHjel1TaIt7H5f04nHO5XMAbUBkr9gIo6ZaR' +
-    'TMSktdS65HuDh55TqmayqKIsCv79u+vz0fXeT4hZTbt2ENlPXJfOLpd2ngJTf/1d1Z/Jmhr939RBjRkW4JGJlW2LCd4lHjFoKeKq' +
-    '4LzLx4LTLp87npVknPiWWNIKaoa4SSynO/R8B5eKZa21g9jen9VXl8Uc6lHMYRMmGIpQUYEEBeF//NOOP44tcldgUC6PAizKREkR' +
-    'E7LE89ChYRIycQhB6pC4c+t+D637yW1t7xWYbXDOL9raQgM4naGT1dvaeAQYGgBu6kw1VEfqofbmcsD7CTCYAobvKLNh5sIhd3t/';
+    'iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAABUUlEQVR4nO2XzW3EIBCFIUoJSwW5' +
+    '0MH6kg5ycBHeIlJBmnARPmwHudgdcEkFUwQ5ObFYMAw/3k30PsmyjYB5zDCMLQQAANRCD7Pljnlu' +
+    'IYRLjvAVWVMIl1W47s/CTIswY8fWc7cI6GG2uj8Xz/NUQQsLPczWFe/zfuq2OiwC2+2S0i+VQ3Ig' +
+    'tl3MtNy2JeZD0wjEvO4TzqVJBEqFc06j6hEIia/hbR/NciC3OHFrQbNj1IydzClMXA6txLGoNK3E' +
+    'RPRjXCmVbIiIrFJKbu+v719cnUGSttBWvO+dixk7+fnxctOWM1c0AiGxpYsQ4ld0ydcoO4kvyynX' +
+    'VpCSZI8O3PO0Lxc4keHkUhFEZN2LM3bv7trgamOdJutzjudccaE51n6pNg6rA6kLcPtflpOY3mSw' +
+    '70P8E/vYLrC/Wru3iD9Bf7XFxzYAAAAAAAAAAPCf+AZMNb5fuO3w0AAAAABJRU5ErkJggg==';
   const dragonCanvas = document.createElement('canvas');
   dragonCanvas.width = dragonCanvas.height = 48;
   const dragonCtx = dragonCanvas.getContext('2d');


### PR DESCRIPTION
## Summary
- swap dragon and hatchling sprites for custom bone dragon art with blue flames
- note sprite replacement in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aea64a7b60832293c719861c107bf3