### PR TITLE
feat: scale affix bonuses with item level

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,39 +1016,42 @@ function generateWeaponName(base){
 let lootMap=new Map();
 
 const WEAPON_AFFIX_POOL = [
-  {k:'crit', min:3, max:8},
-  {k:'ls', min:1, max:5},
-  {k:'mp', min:1, max:4},
+  {k:'crit', min:3, max:8, lvl:.5},
+  {k:'ls', min:1, max:5, lvl:.5},
+  {k:'mp', min:1, max:4, lvl:.5},
   {k:'status'},
-  {k:'kb', min:1, max:2},
-  {k:'atkSpd', min:5, max:15},
-  {k:'pierce', min:1, max:2},
-  {k:'hpMax', min:10, max:25},
-  {k:'speedPct', min:3, max:10},
+  {k:'kb', min:1, max:2, lvl:.5},
+  {k:'atkSpd', min:5, max:15, lvl:.5},
+  {k:'pierce', min:1, max:2, lvl:.5},
+  {k:'hpMax', min:10, max:25, lvl:.5},
+  {k:'speedPct', min:3, max:10, lvl:.5},
 ];
 
 const ARMOR_AFFIX_POOL = [
-  {k:'armor', min:2, max:6, lvl:true},
-  {k:'resFire', min:5, max:15, lvl:true},
-  {k:'resIce', min:5, max:15, lvl:true},
-  {k:'resShock', min:5, max:15, lvl:true},
-  {k:'resMagic', min:5, max:15, lvl:true},
-  {k:'resPoison', min:5, max:15, lvl:true},
-  {k:'hpMax', min:10, max:25},
-  {k:'mpMax', min:10, max:20},
-  {k:'speedPct', min:3, max:10},
-  {k:'ls', min:1, max:5},
-  {k:'mp', min:2, max:8},
-  {k:'crit', min:3, max:8},
+  {k:'armor', min:2, max:6, lvl:1},
+  {k:'resFire', min:5, max:15, lvl:1},
+  {k:'resIce', min:5, max:15, lvl:1},
+  {k:'resShock', min:5, max:15, lvl:1},
+  {k:'resMagic', min:5, max:15, lvl:1},
+  {k:'resPoison', min:5, max:15, lvl:1},
+  {k:'hpMax', min:10, max:25, lvl:.5},
+  {k:'mpMax', min:10, max:20, lvl:.5},
+  {k:'speedPct', min:3, max:10, lvl:.5},
+  {k:'ls', min:1, max:5, lvl:.5},
+  {k:'mp', min:2, max:8, lvl:.5},
+  {k:'crit', min:3, max:8, lvl:.5},
 ];
+
+function levelMult(lvl, factor=1){
+  return 1 + (lvl - 1) * 0.1 * factor;
+}
 
 function affixMods(slot, rarityIdx, lvl=1){
   const R={};
   const mult = RARITY[rarityIdx]?.m || 1;
-  const lvlMult = 1 + (lvl-1) * 0.1; // scale stats with item level
   if(slot==='weapon'){
-    R.dmgMin=Math.floor(rng.int(1,3)*mult*lvlMult);
-    R.dmgMax=Math.floor(rng.int(2,6)*mult*lvlMult);
+    R.dmgMin=Math.floor(rng.int(1,3)*mult*levelMult(lvl));
+    R.dmgMax=Math.floor(rng.int(2,6)*mult*levelMult(lvl));
   }
   const pool = slot==='weapon'?WEAPON_AFFIX_POOL:ARMOR_AFFIX_POOL;
   const maxAff = Math.min(4, 1 + rarityIdx);
@@ -1066,8 +1069,9 @@ function affixMods(slot, rarityIdx, lvl=1){
       else if(roll===3) R.status={k:'freeze',dur:1800,power:0.4,chance,elem:'ice'};
       else              R.status={k:'shock', dur:2000,power:0.25,chance,elem:'shock'};
     }else{
-      const scale = (slot==='weapon' || !a.lvl)?1:lvlMult;
-      R[a.k]=Math.floor(rng.int(a.min,a.max)*mult*scale);
+      const factor = typeof a.lvl === 'number' ? a.lvl : (a.lvl ? 1 : 0);
+      const val = rng.int(a.min,a.max) * mult;
+      R[a.k]=Math.floor(val*levelMult(lvl, factor));
     }
   }
   return R;


### PR DESCRIPTION
## Summary
- scale weapon and armor affix values with item level
- support partial level-based scaling for all affixes

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aeab2e1fc48322ad27e7715b0e7269