### PR TITLE
feat: replace health potion icon with svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Rebalanced loot rarity distribution to favor common and uncommon gear and increased bonuses on rare items.
 - Mini bosses and bosses now appear at twice the size of normal monsters.
 - Replaced dragon and dragon hatchling sprites with a bone dragon sporting blue flames.
+- Health potion icon replaced with custom SVG and retains rarity glow.
 
 - Weapon damage and armor/resistance values now scale with item level and rarity. Player base resistances increase slightly each level.
 

--- a/index.html
+++ b/index.html
@@ -394,6 +394,93 @@ function genSprites(){
   }
   SPRITES.coin = makeCoinAnim();
 
+  // Health potion sprite (12x12 SVG)
+  const hpPotionSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+  <!-- Palette -->
+  <!-- O = outline #6b0018, B = body #d61a3c, H = highlight #ff9aaa, D = deep red #a10f28 -->
+
+  <!-- y=0 -->
+  <rect x="5" y="0" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=1 -->
+  <rect x="4" y="1" width="1" height="1" fill="#6b0018"/>
+  <rect x="5" y="1" width="1" height="1" fill="#d61a3c"/>
+  <rect x="6" y="1" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=2 -->
+  <rect x="3" y="2" width="1" height="1" fill="#6b0018"/>
+  <rect x="4" y="2" width="1" height="1" fill="#d61a3c"/>
+  <rect x="5" y="2" width="1" height="1" fill="#ff9aaa"/>
+  <rect x="6" y="2" width="1" height="1" fill="#d61a3c"/>
+  <rect x="7" y="2" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=3 -->
+  <rect x="2" y="3" width="1" height="1" fill="#6b0018"/>
+  <rect x="3" y="3" width="1" height="1" fill="#d61a3c"/>
+  <rect x="4" y="3" width="1" height="1" fill="#ff9aaa"/>
+  <rect x="5" y="3" width="1" height="1" fill="#d61a3c"/>
+  <rect x="6" y="3" width="1" height="1" fill="#d61a3c"/>
+  <rect x="7" y="3" width="1" height="1" fill="#d61a3c"/>
+  <rect x="8" y="3" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=4 -->
+  <rect x="1" y="4" width="1" height="1" fill="#6b0018"/>
+  <rect x="2" y="4" width="1" height="1" fill="#d61a3c"/>
+  <rect x="3" y="4" width="1" height="1" fill="#d61a3c"/>
+  <rect x="4" y="4" width="1" height="1" fill="#d61a3c"/>
+  <rect x="5" y="4" width="1" height="1" fill="#ff9aaa"/>
+  <rect x="6" y="4" width="1" height="1" fill="#d61a3c"/>
+  <rect x="7" y="4" width="1" height="1" fill="#d61a3c"/>
+  <rect x="8" y="4" width="1" height="1" fill="#d61a3c"/>
+  <rect x="9" y="4" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=5 -->
+  <rect x="1" y="5" width="1" height="1" fill="#6b0018"/>
+  <rect x="2" y="5" width="1" height="1" fill="#d61a3c"/>
+  <rect x="3" y="5" width="1" height="1" fill="#d61a3c"/>
+  <rect x="4" y="5" width="1" height="1" fill="#d61a3c"/>
+  <rect x="5" y="5" width="1" height="1" fill="#ff9aaa"/>
+  <rect x="6" y="5" width="1" height="1" fill="#d61a3c"/>
+  <rect x="7" y="5" width="1" height="1" fill="#d61a3c"/>
+  <rect x="8" y="5" width="1" height="1" fill="#d61a3c"/>
+  <rect x="9" y="5" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=6 -->
+  <rect x="2" y="6" width="1" height="1" fill="#6b0018"/>
+  <rect x="3" y="6" width="1" height="1" fill="#d61a3c"/>
+  <rect x="4" y="6" width="1" height="1" fill="#d61a3c"/>
+  <rect x="5" y="6" width="1" height="1" fill="#d61a3c"/>
+  <rect x="6" y="6" width="1" height="1" fill="#d61a3c"/>
+  <rect x="7" y="6" width="1" height="1" fill="#d61a3c"/>
+  <rect x="8" y="6" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=7 -->
+  <rect x="3" y="7" width="1" height="1" fill="#6b0018"/>
+  <rect x="4" y="7" width="1" height="1" fill="#d61a3c"/>
+  <rect x="5" y="7" width="1" height="1" fill="#d61a3c"/>
+  <rect x="6" y="7" width="1" height="1" fill="#d61a3c"/>
+  <rect x="7" y="7" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=8 -->
+  <rect x="4" y="8" width="1" height="1" fill="#6b0018"/>
+  <rect x="5" y="8" width="1" height="1" fill="#a10f28"/>
+  <rect x="6" y="8" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=9 -->
+  <rect x="5" y="9" width="1" height="1" fill="#a10f28"/>
+
+  <!-- y=10 -->
+  <rect x="5" y="10" width="1" height="1" fill="#6b0018"/>
+
+  <!-- y=11 -->
+  <rect x="4" y="11" width="1" height="1" fill="#6b0018"/>
+  <rect x="5" y="11" width="1" height="1" fill="#6b0018"/>
+  <rect x="6" y="11" width="1" height="1" fill="#6b0018"/>
+</svg>`;
+  const hpPotionImg = new Image();
+  hpPotionImg.src = 'data:image/svg+xml;base64,' + btoa(hpPotionSVG);
+  SPRITES.potion_hp = { cv: hpPotionImg };
+
   // Bat idle animations 24x24
   function makeBatAnim(wing, body){
     const frames = [];
@@ -2111,12 +2198,16 @@ function drawLootIcon(it, x, y){
     const idx = Math.floor(performance.now()/100) % frames.length;
     ctx.drawImage(frames[idx], x, y);
   }else if(it.type==='potion'){
-    ctx.fillRect(x+5, y, 4, 4);
-    ctx.strokeRect(x+5, y, 4, 4);
-    ctx.beginPath();
-    ctx.arc(x+7, y+9, 5, 0, Math.PI*2);
-    ctx.fill();
-    ctx.stroke();
+    if(it.hp){
+      ctx.drawImage(SPRITES.potion_hp.cv, x+1, y+1);
+    }else{
+      ctx.fillRect(x+5, y, 4, 4);
+      ctx.strokeRect(x+5, y, 4, 4);
+      ctx.beginPath();
+      ctx.arc(x+7, y+9, 5, 0, Math.PI*2);
+      ctx.fill();
+      ctx.stroke();
+    }
   }else{
     switch(it.slot){
       case 'weapon':


### PR DESCRIPTION
## Summary
- add inline SVG sprite for health potions
- draw new potion icon when health potions drop, retaining rarity glow
- note update in changelog

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af49ab36208322bbe8d7e66f89d03e