### PR TITLE
Add rotating glowing sword sprite for loot

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,6 +394,71 @@ function genSprites(){
   }
   SPRITES.coin = makeCoinAnim();
 
+  // 12x12 sword/katana loot sprite
+  const swordLootSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+<rect x="5" y="0" width="1" height="1" fill="#7e8da0"/>
+<rect x="6" y="0" width="1" height="1" fill="#7e8da0"/>
+<rect x="4" y="1" width="1" height="1" fill="#2a2f3a"/>
+<rect x="5" y="1" width="1" height="1" fill="#b7c7d6"/>
+<rect x="6" y="1" width="1" height="1" fill="#e8f2ff"/>
+<rect x="7" y="1" width="1" height="1" fill="#2a2f3a"/>
+<rect x="4" y="2" width="1" height="1" fill="#2a2f3a"/>
+<rect x="5" y="2" width="1" height="1" fill="#b7c7d6"/>
+<rect x="6" y="2" width="1" height="1" fill="#e8f2ff"/>
+<rect x="7" y="2" width="1" height="1" fill="#2a2f3a"/>
+<rect x="4" y="3" width="1" height="1" fill="#2a2f3a"/>
+<rect x="5" y="3" width="1" height="1" fill="#b7c7d6"/>
+<rect x="6" y="3" width="1" height="1" fill="#e8f2ff"/>
+<rect x="7" y="3" width="1" height="1" fill="#2a2f3a"/>
+<rect x="4" y="4" width="1" height="1" fill="#2a2f3a"/>
+<rect x="5" y="4" width="1" height="1" fill="#b7c7d6"/>
+<rect x="6" y="4" width="1" height="1" fill="#e8f2ff"/>
+<rect x="7" y="4" width="1" height="1" fill="#2a2f3a"/>
+<rect x="4" y="5" width="1" height="1" fill="#2a2f3a"/>
+<rect x="5" y="5" width="1" height="1" fill="#b7c7d6"/>
+<rect x="6" y="5" width="1" height="1" fill="#e8f2ff"/>
+<rect x="7" y="5" width="1" height="1" fill="#2a2f3a"/>
+<rect x="3" y="6" width="1" height="1" fill="#8a6a20"/>
+<rect x="4" y="6" width="1" height="1" fill="#c8a03c"/>
+<rect x="5" y="6" width="1" height="1" fill="#b7c7d6"/>
+<rect x="6" y="6" width="1" height="1" fill="#e8f2ff"/>
+<rect x="7" y="6" width="1" height="1" fill="#c8a03c"/>
+<rect x="8" y="6" width="1" height="1" fill="#8a6a20"/>
+<rect x="4" y="7" width="1" height="1" fill="#8a6a20"/>
+<rect x="5" y="7" width="1" height="1" fill="#7b4a2b"/>
+<rect x="6" y="7" width="1" height="1" fill="#8f5a3a"/>
+<rect x="7" y="7" width="1" height="1" fill="#8a6a20"/>
+<rect x="5" y="8" width="1" height="1" fill="#7b4a2b"/>
+<rect x="6" y="8" width="1" height="1" fill="#8f5a3a"/>
+<rect x="5" y="9" width="1" height="1" fill="#4b2e19"/>
+<rect x="6" y="9" width="1" height="1" fill="#7b4a2b"/>
+<rect x="5" y="10" width="1" height="1" fill="#4b2e19"/>
+<rect x="6" y="10" width="1" height="1" fill="#7b4a2b"/>
+<rect x="5" y="11" width="1" height="1" fill="#2a2f3a"/>
+<rect x="6" y="11" width="1" height="1" fill="#b7c7d6"/>
+</svg>`;
+  function makeSwordLootAnim(svg){
+    const img = new Image();
+    const sprite = { cv: img, frames: [] };
+    img.onload = () => {
+      const steps = 16;
+      for(let i=0;i<steps;i++){
+        const c=document.createElement('canvas');
+        c.width=c.height=12;
+        const g=c.getContext('2d');
+        g.imageSmoothingEnabled=false;
+        g.translate(6,6);
+        g.rotate(i/steps*Math.PI*2);
+        g.drawImage(img,-6,-6);
+        sprite.frames.push(c);
+      }
+      sprite.cv = sprite.frames[0];
+    };
+    img.src='data:image/svg+xml;base64,'+btoa(svg);
+    return sprite;
+  }
+  SPRITES.sword_loot = makeSwordLootAnim(swordLootSVG);
+
   // Potion sprites with simple rotation animation
   function makePotionAnim(svg){
     const img = new Image();
@@ -2290,6 +2355,19 @@ function monsterAI(m, dt){
 // ===== Drawing =====
 function drawLootIcon(it, x, y){
   ctx.save();
+  const wclass = it.wclass || wclassFromName(it.name);
+  if(it.slot==='weapon' && (wclass==='sword' || wclass==='katana')){
+    const spr = SPRITES.sword_loot;
+    const frames = spr.frames;
+    const r = it.rarity || 0;
+    const rotMs = 600 / (1 + 0.1*r);
+    const idx = frames.length ? Math.floor((performance.now()%rotMs)/rotMs*frames.length) : 0;
+    ctx.shadowColor = it.color;
+    ctx.shadowBlur = 2 + (it.rarity||0)*2;
+    ctx.drawImage(frames[idx] || spr.cv, x+1, y+1);
+    ctx.restore();
+    return;
+  }
   if(it.rarity>=3){
     ctx.shadowColor = it.color;
     ctx.shadowBlur = 8;


### PR DESCRIPTION
## Summary
- embed 12x12 SVG sword loot sprite with pre-rendered rotation frames
- animate sword and katana drops with rarity-based glow and faster spin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af55730dd4832283107bf1b9295c22