### PR TITLE
feat: add spinning pixel sword loot

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,7 +417,7 @@ function genSprites(){
     return sprite;
   }
 
-  function makeBowAnim(svg){
+  function makeSpinAnim(svg){
     const img = new Image();
     const sprite = { cv: img, frames: [] };
     img.onload = () => {
@@ -627,10 +627,20 @@ function genSprites(){
   <rect x="8" y="3" width="1" height="1" fill="#c78549"/>
   <rect x="8" y="8" width="1" height="1" fill="#c78549"/>
   </svg>`;
+  const swordLootSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+  <rect x="5" y="0" width="2" height="7" fill="#dcdcdc"/>
+  <rect x="5" y="0" width="1" height="7" fill="#a0a0a0"/>
+  <rect x="6" y="0" width="1" height="7" fill="#f8f8f8"/>
+  <rect x="4" y="7" width="4" height="1" fill="#b8860b"/>
+  <rect x="3" y="8" width="6" height="1" fill="#8b5a2b"/>
+  <rect x="5" y="9" width="2" height="2" fill="#8b4513"/>
+  <rect x="5" y="11" width="2" height="1" fill="#d2b48c"/>
+  </svg>`;
 
   SPRITES.potion_hp = makePotionAnim(hpPotionSVG);
   SPRITES.potion_mp = makePotionAnim(mpPotionSVG);
-  SPRITES.bow_loot = makeBowAnim(bowLootSVG);
+  SPRITES.bow_loot = makeSpinAnim(bowLootSVG);
+  SPRITES.sword_loot = makeSpinAnim(swordLootSVG);
 
   // Bat idle animations 24x24
   function makeBatAnim(wing, body){
@@ -2358,6 +2368,11 @@ function drawLootIcon(it, x, y){
       case 'weapon':
         if(it.wclass === 'bow'){
           const spr = SPRITES.bow_loot;
+          const frames = spr.frames;
+          const idx = frames.length ? Math.floor(performance.now()/100)%frames.length : 0;
+          ctx.drawImage(frames[idx]||spr.cv, x, y);
+        }else if(it.wclass === 'sword'){
+          const spr = SPRITES.sword_loot;
           const frames = spr.frames;
           const idx = frames.length ? Math.floor(performance.now()/100)%frames.length : 0;
           ctx.drawImage(frames[idx]||spr.cv, x, y);


### PR DESCRIPTION
## Summary
- add generic spin animation helper
- introduce 12x12 pixel sword sprite and register `sword_loot`
- render sword drops with spinning sprite and rarity-based glow

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af5aa8b29083229a5167795bd25422