### PR TITLE
Stack burn duration based on time spent in lava

### DIFF
--- a/index.html
+++ b/index.html
@@ -3033,6 +3033,14 @@ function update(dt){
 
   // attack cooldown
   player.atkCD = Math.max(0, player.atkCD - dt);
+  // standing in lava adds burn duration equal to time spent
+  const tileUnder = map[player.y * MAP_W + player.x];
+  if(tileUnder === T_LAVA){
+    const cur = getEffect(player, 'burn');
+    const dur = (cur ? cur.t : 0) + dt * 2;
+    const pow = cur ? cur.power : 1.0;
+    applyStatus(player, 'burn', dur, pow);
+  }
   // status tick
   tickEffects(player, dt);
 


### PR DESCRIPTION
## Summary
- Extend burn status duration when standing on lava tiles, ensuring time spent in lava converts to ongoing burn damage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af8917802083229fa5191fc68ec632