### PR TITLE
docs: add controls link and update multi-file notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Warrior class no longer registers as a mage.
 - Warrior skill menu now displays ability descriptions.
 
+### Docs
+- Document multi-file layout and link to the standalone controls page from the start screen.
+
 ## 2025-08-26
 ### Added
 - Directional player attacks and a full projectile system (per-weapon reach/cooldowns; melee vs. ranged profiles). (27799af)

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Then visit [http://localhost:8000](http://localhost:8000).
 See [`controls.html`](controls.html) for a standalone controls page.
 
 ## Development Notes
-- All game logic, styling, and assets live inline within `index.html` to keep the project self-contained.
-- Constants such as tile sizes and game balance are defined near the top of the script for quick tweaking.
+ - Game logic now lives in `game.js` and styling in `style.css`, keeping `index.html` focused on layout.
+ - Constants such as tile sizes and game balance are defined near the top of the script for quick tweaking.
 
 ## Contributing
 1. Fork and clone the repository.

--- a/index.html
+++ b/index.html
@@ -91,10 +91,11 @@
     </div>
 
     <p class="hint" style="margin-top:10px">All sprites (player, monsters, portal, shop) are generated at runtime.</p>
-    <div style="display:flex;gap:8px;margin-top:8px">
-      <button id="playBtn" class="btn">Play</button>
-      <button class="btn" onclick="alert('Thanks for playing!')">Quit</button>
-    </div>
+      <div style="display:flex;gap:8px;margin-top:8px">
+        <button id="playBtn" class="btn">Play</button>
+        <button class="btn" onclick="alert('Thanks for playing!')">Quit</button>
+        <a href="controls.html" class="btn" style="text-decoration:none;display:inline-block">Controls</a>
+      </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- link start menu to `controls.html`
- document multi-file layout in README and changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0703eb60483228bddae4f351725c5