### PR TITLE
Add elemental mage sprite variants

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -93,25 +93,25 @@ function genSprites(){
   SPRITES.player_warrior = makePlayerWarriorAnim();
 
   // Mage animation 24x24
-  function makePlayerMageAnim(){
+  function makePlayerMageAnim(robeCol, orbCol){
     function drawFrame(g, oy, step){
       // staff
       px(g,20+step,6+oy,2,12,'#8b5e3c');
-      px(g,19+step,4+oy,4,4,'#b84aff');
+      px(g,19+step,4+oy,4,4,orbCol);
       // boots
       px(g,7,18+oy,10,3,'#3a2d1a');
       // robe
-      px(g,6,8+oy,12,10,'#4a3a8a');
-      px(g,5,10+oy,2,8,'#4a3a8a');
-      px(g,17,10+oy,2,8,'#4a3a8a');
+      px(g,6,8+oy,12,10,robeCol);
+      px(g,5,10+oy,2,8,robeCol);
+      px(g,17,10+oy,2,8,robeCol);
       // arms
-      px(g,4-step,10+oy,2,6,'#4a3a8a');
-      px(g,18+step,10+oy,2,6,'#4a3a8a');
+      px(g,4-step,10+oy,2,6,robeCol);
+      px(g,18+step,10+oy,2,6,robeCol);
       // head & hood
       px(g,8,2+oy,8,6,'#e3c6a6');
       px(g,9,4+oy,2,2,'#000'); px(g,13,4+oy,2,2,'#000');
-      px(g,7,1+oy,10,2,'#4a3a8a');
-      px(g,6,2+oy,12,2,'#4a3a8a');
+      px(g,7,1+oy,10,2,robeCol);
+      px(g,6,2+oy,12,2,robeCol);
       outline(g,24);
     }
     const idle=[], move=[];
@@ -130,7 +130,11 @@ function genSprites(){
     }
     return { idle, move };
   }
-  SPRITES.player_mage = makePlayerMageAnim();
+  SPRITES.player_mage = makePlayerMageAnim('#4a3a8a','#b84aff');
+  SPRITES.player_mage_fire = makePlayerMageAnim('#ff6b4a','#ff9b4a');
+  SPRITES.player_mage_ice = makePlayerMageAnim('#7dd3fc','#bdeafe');
+  SPRITES.player_mage_shock = makePlayerMageAnim('#facc15','#fde047');
+  SPRITES.player_mage_poison = makePlayerMageAnim('#76d38b','#9fe2a1');
 
   // Slime idle animations 24x24
   function makeSlimeAnim(c1, c2, c3){

--- a/game.js
+++ b/game.js
@@ -96,6 +96,18 @@ const skillTrees={
     {name:'Shield Bash',desc:'Bash an enemy for 80% more damage and shock them (15 stamina).',cost:3,cast:'shieldBash'}
   ]}
 };
+
+function updateMageSprite(){
+  if(player.class!=='mage'){ playerSpriteKey='player_warrior'; return; }
+  let elem='magic';
+  if(player.boundSpell){
+    const ab=magicTrees[player.boundSpell.tree].abilities[player.boundSpell.idx];
+    elem = ab.elem || 'magic';
+  }
+  const key = elem==='magic' ? 'player_mage' : `player_mage_${elem}`;
+  playerSpriteKey = ASSETS.sprites[key] ? key : 'player_mage';
+}
+
 // Monsters now have richer AI with per-type patterns and scaling
 // {x,y,rx,ry,type,hp,hpMax,dmgMin,dmgMax,atkCD,moveCD,xp,state:{...},hitFlash,effects:[]}
 let monsters=[];
@@ -2279,6 +2291,7 @@ function bindSpell(treeName, idx){
   player.boundSpell={tree:treeName, idx};
   const ab=magicTrees[treeName].abilities[idx];
   hudSpell.textContent=ab.name;
+  updateMageSprite();
   showToast(`Bound ${ab.name} to Q`);
 }
 
@@ -2568,8 +2581,8 @@ function startGame(){
   // class pick -> sprite & stats
   const cSel = document.querySelector('input[name="class"]:checked');
   player.class = (cSel?.value==='mage')?'mage':'warrior';
-  playerSpriteKey = player.class==='mage' ? 'player_mage' : 'player_warrior';
   player.boundSpell=null; player.boundSkill=null;
+  updateMageSprite();
   player.score=0; player.kills=0; player.timeSurvived=0; player.floorsCleared=0; scoreUpdateTimer=0; updateScoreUI();
   hudAbilityLabel.textContent = player.class==='mage'?'Spell:':'Skill:';
   hudFloor.textContent=floorNum; hudSeed.textContent=seed>>>0; hudGold.textContent=player.gold; hudLvl.textContent=player.lvl;


### PR DESCRIPTION
## Summary
- Generate mage sprites with element-themed robe and staff colors
- Switch mage appearance based on bound spell element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a11941b4832288665777c3db3457