### PR TITLE
Persist floor and gear on page unload

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An offline HTML5 dungeon crawler with inline sprites, now featuring warrior, mag
 
 Recent updates add varied combat sound effects and multiple music tracks that rotate every floor.
 
+The game now auto-saves your current floor and equipped gear to local storage when you leave the page. Use the pause menu to manually save or load this progress.
+
 ## Play the Game
 Open `index.html` in your browser.  
 For full functionality, serve the directory with a local server:


### PR DESCRIPTION
## Summary
- Save only floor number, player basics, and equipped gear to local storage
- Restore a fresh map with saved equipment and level when loading
- Automatically save progress before closing the page

## Testing
- `node --check --experimental-default-type=module game.js`

------
https://chatgpt.com/codex/tasks/task_e_68b0ab15acfc832289fbff37ff4c6f1a