### PR TITLE
Modularize combat calculations and add tests

### DIFF
--- a/modules/combat.js
+++ b/modules/combat.js
@@ -1,8 +1,72 @@
 /**
- * Combat-related logic placeholder.
- * Damage calculation and attack handling will be moved here.
+ * Combat-related logic.
+ * Provides functions for calculating and applying damage.
  */
-export function calculateDamage(base, modifiers = {}) {
-  // TODO: implement combat calculations
-  return base;
+
+function clamp(a, b, x) {
+  return Math.max(a, Math.min(b, x));
+}
+
+export function calculateDamage(base, {
+  type = 'physical',
+  armor = 0,
+  floor = 1,
+  resFire = 0,
+  resIce = 0,
+  resShock = 0,
+  resMagic = 0,
+  resPoison = 0,
+  shock = 0
+} = {}) {
+  const K = 50 + 10 * Math.max(0, floor - 1);
+  const armorDR = Math.max(0, Math.min(0.8, armor / (armor + K)));
+  let afterArmor = base;
+  if(type === 'physical' || type === 'ranged') {
+    afterArmor = Math.max(1, Math.floor(base * (1 - armorDR)));
+  }
+  const cap = 75;
+  const resPct = type === 'fire' ? clamp(0, cap, resFire) :
+                 type === 'ice' ? clamp(0, cap, resIce) :
+                 type === 'shock' ? clamp(0, cap, resShock) :
+                 type === 'magic' ? clamp(0, cap, resMagic) :
+                 type === 'poison' ? clamp(0, cap, resPoison) : 0;
+  const eff = Math.max(1, Math.floor(afterArmor * (1 - resPct/100) * (1 + shock)));
+  return eff;
+}
+
+/**
+ * Applies damage to the player entity and returns the effective damage.
+ * Options should provide hooks for side effects used by the main game.
+ */
+export function applyDamageToPlayer(player, dmg, {
+  type = 'physical',
+  floor = 1,
+  damageTexts = [],
+  getEffectPower = () => 0,
+  playHit = () => {},
+  showRespawn = () => {}
+} = {}) {
+  player.combatTimer = 0;
+  player.healAcc = 0;
+  const shock = getEffectPower(player, 'shock') || 0;
+  const eff = calculateDamage(dmg, {
+    type,
+    armor: player.armor || 0,
+    floor,
+    resFire: player.resFire || 0,
+    resIce: player.resIce || 0,
+    resShock: player.resShock || 0,
+    resMagic: player.resMagic || 0,
+    resPoison: player.resPoison || 0,
+    shock
+  });
+  player.hp = Math.max(0, player.hp - eff);
+  const dmgCol = type==='magic' ? '#b84aff' :
+                 type==='poison'? '#76d38b' : '#ff6b6b';
+  damageTexts.push({ tx:player.x, ty:player.y, text:`-${eff}`, color:dmgCol, age:0, ttl:900 });
+  playHit();
+  if(player.hp === 0) {
+    showRespawn();
+  }
+  return eff;
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "2d-game",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/combat.test.js
+++ b/test/combat.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateDamage, applyDamageToPlayer } from '../modules/combat.js';
+
+test('armor reduces physical damage', () => {
+  const result = calculateDamage(100, { type: 'physical', armor: 50, floor: 1 });
+  assert.equal(result, 50);
+});
+
+test('resistance reduces elemental damage', () => {
+  const result = calculateDamage(100, { type: 'fire', resFire: 25 });
+  assert.equal(result, 75);
+});
+
+test('applyDamageToPlayer updates hp and returns damage', () => {
+  const player = { hp: 100, armor: 0, resFire: 0, resIce: 0, resShock: 0, resMagic: 0, resPoison: 0, x:0, y:0 };
+  const damageTexts = [];
+  let hit = false;
+  let respawn = false;
+  const eff = applyDamageToPlayer(player, 30, {
+    damageTexts,
+    playHit: () => { hit = true; },
+    showRespawn: () => { respawn = true; }
+  });
+  assert.equal(eff, 30);
+  assert.equal(player.hp, 70);
+  assert.ok(hit);
+  assert.equal(respawn, false);
+  assert.equal(damageTexts.length, 1);
+});


### PR DESCRIPTION
## Summary
- move player damage calculations into `modules/combat`
- import combat module in `game.js` to apply damage via a shared helper
- add Node test setup with unit tests for damage and resistance logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b6fc80188322a605bb5bd0da9c9f