### PR TITLE
Fix level up XP bar update

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,7 +1,7 @@
 import { initAudio, playFootstep, playAttack, playHit, startMusic, nextMusic } from './modules/audio.js';
 import { keys, initInput } from './modules/input.js';
 import { player, playerSpriteKey, magicTrees, skillTrees, updatePlayerSprite } from './modules/player.js';
-import { hpFill, mpFill, hpLbl, mpLbl, hudFloor, hudSeed, hudGold, hudDmg, hudScore, hudKills, xpFill, xpLbl, hudLvl, hudSpell, hudAbilityLabel, updateResourceUI, updateScoreUI, toggleActionLog, showToast, showBossAlert, showRespawn } from './modules/ui.js';
+import { hpFill, mpFill, hpLbl, mpLbl, hudFloor, hudSeed, hudGold, hudDmg, hudScore, hudKills, xpFill, xpLbl, hudLvl, hudSpell, hudAbilityLabel, updateResourceUI, updateXPUI, updateScoreUI, toggleActionLog, showToast, showBossAlert, showRespawn } from './modules/ui.js';
 import { TILE, MAP_W, MAP_H, T_EMPTY, T_FLOOR, T_WALL, T_TRAP, T_LAVA, TRAP_CHANCE, LAVA_CHANCE, map, fog, vis, rooms, stairs, merchant, merchantStyle, torches, lavaTiles, spikeTraps, walkable, canMoveFrom, resetMapState } from './modules/map.js';
 import { startLoop } from './modules/loop.js';
 import { applyDamageToPlayer as coreApplyDamageToPlayer } from './modules/combat.js';
@@ -1749,8 +1749,7 @@ function draw(dt){
   // HUD
   hpFill.style.width=(100*player.hp/player.hpMax).toFixed(0)+'%';
   updateResourceUI();
-  const xpPct = Math.min(100, Math.floor(100*player.xp/Math.max(1,player.xpToNext)));
-  xpFill.style.width = xpPct+'%'; xpLbl.textContent=`XP ${player.xp}/${player.xpToNext}`; hudLvl.textContent=player.lvl;
+  updateXPUI();
   hpLbl.textContent=`HP ${player.hp}/${player.hpMax}`;
 }
 
@@ -2336,6 +2335,7 @@ function levelUp(){
   else player.sp = player.spMax;
   hpFill.style.width = `${(player.hp/player.hpMax)*100}%`;
   updateResourceUI();
+  updateXPUI();
   hpLbl.textContent = `HP ${player.hp}/${player.hpMax}`;
   showToast(`Level up! Lv ${player.lvl}`);
   showToast(player.class==='mage'?'Gained magic point':'Gained skill point');

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -29,6 +29,13 @@ function updateResourceUI(){
   }
 }
 
+function updateXPUI(){
+  const pct=Math.min(100, Math.floor(100*player.xp/Math.max(1,player.xpToNext)));
+  xpFill.style.width=`${pct}%`;
+  xpLbl.textContent=`XP ${player.xp}/${player.xpToNext}`;
+  hudLvl.textContent=player.lvl;
+}
+
 function updateScoreUI(){
   if(hudScore) hudScore.textContent = Math.floor(player.score);
   if(hudKills) hudKills.textContent = player.kills;
@@ -83,7 +90,7 @@ export {
   hudFloor, hudSeed, hudGold, hudDmg,
   hudScore, hudKills, xpFill, xpLbl,
   hudLvl, hudSpell, hudAbilityLabel,
-  updateResourceUI, updateScoreUI,
+  updateResourceUI, updateXPUI, updateScoreUI,
   renderActionLog, toggleActionLog,
   showToast, showBossAlert, showRespawn
 };

--- a/test/xp-ui.test.js
+++ b/test/xp-ui.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const ids=['hpFill','mpFill','hpLbl','mpLbl','hudFloor','hudSeed','hudGold','hudDmg','hudScore','hudKills','xpFill','xpLbl','hudLvl','hudSpell','hudAbilityLabel'];
+const elements={};
+for(const id of ids){ elements[id]={ style:{}, textContent:'' }; }
+
+global.document={
+  getElementById:id=>elements[id],
+  createElement:()=>({ style:{}, textContent:'', remove:()=>{} }),
+  body:{ appendChild:()=>{} }
+};
+
+test('updateXPUI updates XP bar and level label', async () => {
+  const { updateXPUI } = await import('../modules/ui.js');
+  const { player } = await import('../modules/player.js');
+  player.xp=30; player.xpToNext=60; player.lvl=2;
+  updateXPUI();
+  assert.equal(elements.xpFill.style.width, '50%');
+  assert.equal(elements.xpLbl.textContent, 'XP 30/60');
+  assert.equal(String(elements.hudLvl.textContent), '2');
+});


### PR DESCRIPTION
## Summary
- add `updateXPUI` helper to centralize XP bar refresh
- invoke `updateXPUI` during rendering and player level ups
- cover XP UI behavior with automated test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0c2d0de148322aea1774958b768bb