### PR TITLE
refactor: extract map layer rendering helper

### DIFF
--- a/game.js
+++ b/game.js
@@ -5,6 +5,7 @@ import { hpFill, mpFill, hpLbl, mpLbl, hudFloor, hudSeed, hudGold, hudDmg, hudSc
 import { TILE, MAP_W, MAP_H, T_EMPTY, T_FLOOR, T_WALL, T_TRAP, T_LAVA, TRAP_CHANCE, LAVA_CHANCE, map, fog, vis, rooms, stairs, merchant, merchantStyle, torches, lavaTiles, spikeTraps, walkable, canMoveFrom, resetMapState } from './modules/map.js';
 import { startLoop } from './modules/loop.js';
 import { applyDamageToPlayer as coreApplyDamageToPlayer } from './modules/combat.js';
+import { renderLayers } from './modules/rendering.js';
 
 // ===== Config / Globals =====
 let VIEW_W=window.innerWidth, VIEW_H=window.innerHeight;
@@ -1561,8 +1562,7 @@ function draw(dt){
   ctx.clearRect(0,0,VIEW_W,VIEW_H);
   ctx.save();
   ctx.scale(zoom, zoom);
-  ctx.drawImage(floorLayer, -camX, -camY);
-  ctx.drawImage(wallLayer, -camX, -camY);
+  renderLayers(ctx, floorLayer, wallLayer, camX, camY);
 
   // hazards
   const now = performance.now();

--- a/modules/rendering.js
+++ b/modules/rendering.js
@@ -1,7 +1,17 @@
 /**
  * Rendering helpers will gradually move here.
- * Currently a stub to organize future drawing logic.
+ * Currently provides basic map layer drawing.
  */
-export function render() {
-  // TODO: implement rendering functions
+
+/**
+ * Draw pre-rendered floor and wall layers using camera offsets.
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {HTMLCanvasElement} floorLayer
+ * @param {HTMLCanvasElement} wallLayer
+ * @param {number} camX
+ * @param {number} camY
+ */
+export function renderLayers(ctx, floorLayer, wallLayer, camX, camY) {
+  ctx.drawImage(floorLayer, -camX, -camY);
+  ctx.drawImage(wallLayer, -camX, -camY);
 }

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { renderLayers } from '../modules/rendering.js';
+
+test('renderLayers draws floor and wall layers with camera offset', () => {
+  const calls = [];
+  const ctx = { drawImage: (...args) => calls.push(args) };
+  const floor = {};
+  const wall = {};
+  renderLayers(ctx, floor, wall, 10, 20);
+  assert.deepEqual(calls, [[floor, -10, -20], [wall, -10, -20]]);
+});


### PR DESCRIPTION
## Summary
- centralize floor and wall drawing into new `renderLayers` helper
- use helper in `draw` routine and add unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c476f4908322949f0fed7834608e