### PR TITLE
Add class-specific skill trees for playable classes

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,7 @@
 import { initAudio, playFootstep, playAttack, playHit, playCalmMusic, playCombatMusic, playBossMusic } from './modules/audio.js';
 import { keys, initInput } from './modules/input.js';
-import { player, playerSpriteKey, magicTrees, skillTrees, updatePlayerSprite } from './modules/player.js';
+import { player, playerSpriteKey, updatePlayerSprite } from './modules/player.js';
+import { skillTrees } from './modules/skillTrees.js';
 import { inventory, SLOTS, BAG_SIZE, POTION_BAG_SIZE } from './modules/playerInventory.js';
 import { hpFill, mpFill, hpLbl, mpLbl, hudFloor, hudSeed, hudGold, hudDmg, hudScore, hudKills, xpFill, xpLbl, hudLvl, hudSpell, hudAbilityLabel, updateResourceUI, updateXPUI, updateScoreUI, toggleActionLog, showToast, showBossAlert, showRespawn } from './modules/ui.js';
 import { TILE, MAP_W, MAP_H, T_EMPTY, T_FLOOR, T_WALL, T_TRAP, T_LAVA, TRAP_CHANCE, LAVA_CHANCE, map, fog, vis, rooms, stairs, merchant, merchantStyle, torches, lavaTiles, spikeTraps, walkable, canMoveFrom, resetMapState } from './modules/map.js';
@@ -2002,16 +2003,16 @@ function redrawMagic(){
   let panel=document.getElementById('magic');
   if(!panel){ panel=document.createElement('div'); panel.id='magic'; panel.className='panel'; document.body.appendChild(panel); }
   let html = `<div class="section-title">Magic Points: ${player.magicPoints}</div>`;
-  for(const treeName of ['healing','damage','dot']){
-    const tree=magicTrees[treeName];
+  for(const treeName in skillTrees.mage){
+    const tree=skillTrees.mage[treeName];
     html += `<div class="section-title">${tree.display}</div><div>`;
     tree.abilities.forEach((ab,i)=>{
-      const unlocked=player.magic[treeName][i];
+      const unlocked=player.skills[treeName][i];
       const bind = player.boundSpell && player.boundSpell.tree===treeName && player.boundSpell.idx===i;
       if(unlocked){
         html += `<div class="list-row"><div>${ab.name}</div><div>${bind?'<span class="green">Bound</span>':`<button class="btn sml" data-bind="${treeName}-${i}">Bind</button>`}</div></div>`;
       }else{
-        const prevUnlocked = i===0 || player.magic[treeName][i-1];
+        const prevUnlocked = i===0 || player.skills[treeName][i-1];
         const dis = (player.magicPoints<ab.cost || !prevUnlocked)?'disabled':'';
         html += `<div class="list-row"><div>${ab.name}</div><div><button class="btn sml" data-unlock="${treeName}-${i}" ${dis}>Unlock (${ab.cost})</button></div></div>`;
       }
@@ -2037,8 +2038,7 @@ function redrawSkills(){
   let panel=document.getElementById('skills');
   if(!panel){ panel=document.createElement('div'); panel.id='skills'; panel.className='panel'; document.body.appendChild(panel); }
   let html = `<div class="section-title">Skill Points: ${player.skillPoints}</div>`;
-  for(const [treeName, tree] of Object.entries(skillTrees)){
-    if(tree.class && tree.class!==player.class) continue;
+  for(const [treeName, tree] of Object.entries(skillTrees[player.class])){
     html += `<div class="section-title">${tree.display}</div><div>`;
     tree.abilities.forEach((ab,i)=>{
       const unlocked=player.skills[treeName][i];
@@ -2068,7 +2068,7 @@ function redrawSkills(){
 function toggleSkills(){ if(player.class!=='warrior' && player.class!=='rogue') return; let panel=document.getElementById('skills'); if(!panel){ redrawSkills(); panel=document.getElementById('skills'); } if(!panel) return; const show=panel.style.display===''||panel.style.display==='none'; panel.style.display=show?'block':'none'; if(show) redrawSkills(); updatePaused(); }
 
 function unlockSkill(treeName, idx){
-  const ab=skillTrees[treeName].abilities[idx];
+  const ab=skillTrees[player.class][treeName].abilities[idx];
   if(player.skills[treeName][idx]) return;
   if(idx>0 && !player.skills[treeName][idx-1]){ showToast('Unlock previous ability first'); return; }
   if(player.skillPoints>=ab.cost){ player.skillPoints-=ab.cost; player.skills[treeName][idx]=true; showToast(`Unlocked ${ab.name}`); recalcStats(); }
@@ -2078,23 +2078,23 @@ function unlockSkill(treeName, idx){
 function bindSkill(treeName, idx){
   if(!player.skills[treeName][idx]){ showToast('Ability not unlocked'); return; }
   player.boundSkill={tree:treeName, idx};
-  const ab=skillTrees[treeName].abilities[idx];
+  const ab=skillTrees[player.class][treeName].abilities[idx];
   hudSpell.textContent=ab.name;
   showToast(`Bound ${ab.name} to Q`);
 }
 
 function unlockSpell(treeName, idx){
-  const ab=magicTrees[treeName].abilities[idx];
-  if(player.magic[treeName][idx]) return;
-  if(idx>0 && !player.magic[treeName][idx-1]){ showToast('Unlock previous ability first'); return; }
-  if(player.magicPoints>=ab.cost){ player.magicPoints-=ab.cost; player.magic[treeName][idx]=true; showToast(`Unlocked ${ab.name}`); }
+  const ab=skillTrees.mage[treeName].abilities[idx];
+  if(player.skills[treeName][idx]) return;
+  if(idx>0 && !player.skills[treeName][idx-1]){ showToast('Unlock previous ability first'); return; }
+  if(player.magicPoints>=ab.cost){ player.magicPoints-=ab.cost; player.skills[treeName][idx]=true; showToast(`Unlocked ${ab.name}`); }
   else showToast('Not enough points');
 }
 
 function bindSpell(treeName, idx){
-  if(!player.magic[treeName][idx]){ showToast('Ability not unlocked'); return; }
+  if(!player.skills[treeName][idx]){ showToast('Ability not unlocked'); return; }
   player.boundSpell={tree:treeName, idx};
-  const ab=magicTrees[treeName].abilities[idx];
+  const ab=skillTrees.mage[treeName].abilities[idx];
   hudSpell.textContent=ab.name;
   updatePlayerSprite();
   showToast(`Bound ${ab.name} to Q`);
@@ -2102,8 +2102,8 @@ function bindSpell(treeName, idx){
 
 function castSelectedSpell(){
   const b=player.boundSpell; if(!b){ showToast('No spell bound'); return; }
-  const ab=magicTrees[b.tree].abilities[b.idx];
-  if(!player.magic[b.tree][b.idx]){ showToast('Spell locked'); return; }
+  const ab=skillTrees.mage[b.tree].abilities[b.idx];
+  if(!player.skills[b.tree][b.idx]){ showToast('Spell locked'); return; }
   if(player.mp<ab.mp){ showToast('Not enough mana'); return; }
   player.mp-=ab.mp; updateResourceUI();
   if(ab.type==='heal'){
@@ -2126,7 +2126,7 @@ function castSelectedSpell(){
 
 function castBoundSkill(){
   const b=player.boundSkill; if(!b){ showToast('No skill bound'); return; }
-  const ab=skillTrees[b.tree].abilities[b.idx];
+  const ab=skillTrees[player.class][b.tree].abilities[b.idx];
   if(!player.skills[b.tree][b.idx]){ showToast('Skill locked'); return; }
   if(ab.cast==='powerStrike') castPowerStrike();
   else if(ab.cast==='whirlwind') castWhirlwind();
@@ -2284,8 +2284,8 @@ function loadGame(){
   recomputeFOV(); redrawInventory();
   hudAbilityLabel.textContent = player.class==='mage'?'Spell:':'Skill:';
   hudSpell.textContent = player.class==='mage'
-    ? (player.boundSpell ? magicTrees[player.boundSpell.tree].abilities[player.boundSpell.idx].name : 'None')
-    : (player.boundSkill ? skillTrees[player.boundSkill.tree].abilities[player.boundSkill.idx].name : 'None');
+    ? (player.boundSpell ? skillTrees.mage[player.boundSpell.tree].abilities[player.boundSpell.idx].name : 'None')
+    : (player.boundSkill ? skillTrees[player.class][player.boundSkill.tree].abilities[player.boundSkill.idx].name : 'None');
   updateResourceUI();
   updateScoreUI();
   toggleEscMenu(false); showToast('Game loaded');
@@ -2401,13 +2401,12 @@ function applyGearBonuses(stats){
 }
 
 function applySkillBonuses(stats){
-  for(const treeName in skillTrees){
-    const tree=skillTrees[treeName];
-    if(tree.class && tree.class!==player.class) continue;
+  const trees=skillTrees[player.class];
+  for(const treeName in trees){
     const arr=player.skills[treeName]||[];
     arr.forEach((u,i)=>{
       if(!u) return;
-      const b=skillTrees[treeName].abilities[i].bonus||{};
+      const b=trees[treeName].abilities[i].bonus||{};
       accumulate(stats, b);
     });
   }
@@ -2457,8 +2456,8 @@ function startGame(){
   hpLbl.textContent = `HP ${player.hp}/${player.hpMax}`;
   recomputeFOV();
   hudSpell.textContent = player.class==='mage'
-    ? (player.boundSpell ? magicTrees[player.boundSpell.tree].abilities[player.boundSpell.idx].name : 'None')
-    : (player.boundSkill ? skillTrees[player.boundSkill.tree].abilities[player.boundSkill.idx].name : 'None');
+    ? (player.boundSpell ? skillTrees.mage[player.boundSpell.tree].abilities[player.boundSpell.idx].name : 'None')
+    : (player.boundSkill ? skillTrees[player.class][player.boundSkill.tree].abilities[player.boundSkill.idx].name : 'None');
   const smoothToggle=document.getElementById('smoothToggle'); const speedRange=document.getElementById('speedRange');
   if(smoothToggle){ smoothToggle.checked = smoothEnabled; smoothToggle.addEventListener('change', e=>{ smoothEnabled = e.target.checked; if(!smoothEnabled){ player.rx=player.x; player.ry=player.y; } }); }
   if(speedRange){ baseStepDelay = player.stepDelay; speedRange.value = String(baseStepDelay); speedRange.addEventListener('input', e=>{ const v=parseInt(e.target.value,10); if(!isNaN(v)) baseStepDelay=v; }); }

--- a/modules/player.js
+++ b/modules/player.js
@@ -2,6 +2,7 @@
 import { stats } from './playerStats.js';
 import { inventory } from './playerInventory.js';
 import { progression } from './playerProgression.js';
+import { skillTrees } from './skillTrees.js';
 
 const player = {
   x: 0,
@@ -21,67 +22,11 @@ Object.assign(player, stats, inventory, progression);
 
 let playerSpriteKey = 'player_warrior';
 
-const magicTrees={
-  healing:{display:'Healing',abilities:[
-    {name:'Heal I',type:'heal',value:30,mp:10,cost:1},
-    {name:'Heal II',type:'heal',value:60,mp:20,cost:2},
-    {name:'Heal III',type:'heal',value:120,mp:30,cost:3},
-    {name:'Heal IV',type:'heal',value:null,mp:40,cost:4},
-    {name:'Heal V',type:'heal',value:null,mp:60,cost:5},
-    {name:'Divine Light',type:'heal',value:null,mp:80,cost:9}
-  ]},
-  damage:{display:'Damage',abilities:[
-    {name:'Fire Bolt',type:'damage',dmg:15,mp:10,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2000,power:1.0,chance:1}},
-    {name:'Ice Spike',type:'damage',dmg:40,mp:15,cost:2,range:8,elem:'ice',status:{k:'freeze',dur:1800,power:0.4,chance:1}},
-    {name:'Lightning Bolt',type:'damage',dmg:65,mp:20,cost:3,range:9,elem:'shock',status:{k:'shock',dur:2000,power:0.25,chance:1}},
-    {name:'Arcane Blast',type:'damage',dmg:90,mp:30,cost:4,range:9,elem:'magic'},
-    {name:'Meteor',type:'damage',dmg:120,mp:40,cost:5,range:9,elem:'fire',status:{k:'burn',dur:3000,power:1.5,chance:1}},
-    {name:'Void Ray',type:'damage',dmg:150,mp:60,cost:9,range:10,elem:'magic'}
-  ]},
-  dot:{display:'Damage Over Time',abilities:[
-    {name:'Ignite',type:'dot',dmg:8,mp:12,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2200,power:1.0,chance:1}},
-    {name:'Scorch',type:'dot',dmg:18,mp:16,cost:2,range:8,elem:'fire',status:{k:'burn',dur:2600,power:1.1,chance:1}},
-    {name:'Sear',type:'dot',dmg:28,mp:20,cost:3,range:8,elem:'fire',status:{k:'burn',dur:3000,power:1.2,chance:1}},
-    {name:'Inferno',type:'dot',dmg:38,mp:25,cost:4,range:8,elem:'fire',status:{k:'burn',dur:3400,power:1.3,chance:1}},
-    {name:'Conflagrate',type:'dot',dmg:48,mp:28,cost:5,range:8,elem:'fire',status:{k:'burn',dur:3800,power:1.4,chance:1}},
-    {name:'Hellfire',type:'dot',dmg:60,mp:35,cost:9,range:8,elem:'fire',status:{k:'burn',dur:4200,power:1.5,chance:1}}
-  ]}
-};
-
-const skillTrees={
-  offense:{display:'Offense',abilities:[
-    {name:'Precision',desc:'Increase critical chance by 5%.',bonus:{crit:5},cost:1},
-    {name:'Berserk',desc:'Increase attack damage by 2.',bonus:{dmgMin:2,dmgMax:2},cost:2},
-    {name:'Cleave',desc:'Increase attack damage by 3.',bonus:{dmgMin:3,dmgMax:3},cost:3},
-    {name:'Earthshatter',desc:'Increase attack damage by 4.',bonus:{dmgMin:4,dmgMax:4},cost:4},
-    {name:'Bloodlust',desc:'Increase attack damage by 5.',bonus:{dmgMin:5,dmgMax:5},cost:5},
-    {name:'Dominance',desc:'Increase attack damage by 6.',bonus:{dmgMin:6,dmgMax:6},cost:9}
-  ]},
-  defense:{display:'Defense',abilities:[
-    {name:'Toughness',desc:'Increase max HP by 20.',bonus:{hpMax:20},cost:1},
-    {name:'Shield Wall',desc:'Increase armor by 2.',bonus:{armor:2},cost:2},
-    {name:'Fortify',desc:'Increase max HP by 20.',bonus:{hpMax:20},cost:3},
-    {name:'Stone Skin',desc:'Increase armor by 2.',bonus:{armor:2},cost:4},
-    {name:'Guardian',desc:'Increase max HP by 30.',bonus:{hpMax:30},cost:5},
-    {name:'Unbreakable',desc:'Increase armor by 3.',bonus:{armor:3},cost:9}
-  ]},
-  techniques:{display:'Techniques',class:'warrior',abilities:[
-    {name:'Power Strike',desc:'Spend 20 stamina to strike for 40% more damage.',cost:1,cast:'powerStrike'},
-    {name:'Whirlwind',desc:'Spin and hit nearby foes for 60% more damage (30 stamina).',cost:2,cast:'whirlwind'},
-    {name:'Shield Bash',desc:'Bash an enemy for 80% more damage and shock them (15 stamina).',cost:3,cast:'shieldBash'}
-  ]},
-  tricks:{display:'Tricks',class:'rogue',abilities:[
-    {name:'Deadly Precision',desc:'Increase critical chance by 10%.',bonus:{crit:10},cost:1},
-    {name:'Poison Strike',desc:'Spend 20 stamina to strike and poison an enemy.',cost:2,cast:'poisonStrike'},
-    {name:'Vanish',desc:'Spend 25 stamina to become invisible for 4 seconds.',cost:3,cast:'vanish'}
-  ]}
-};
-
 function updatePlayerSprite(){
   if(player.class==='mage'){
     let elem='magic';
     if(player.boundSpell){
-      const ab=magicTrees[player.boundSpell.tree].abilities[player.boundSpell.idx];
+      const ab=skillTrees.mage[player.boundSpell.tree].abilities[player.boundSpell.idx];
       elem = ab.elem || 'magic';
     }
     const key = elem==='magic' ? 'player_mage' : `player_mage_${elem}`;
@@ -93,5 +38,5 @@ function updatePlayerSprite(){
   }
 }
 
-export { player, playerSpriteKey, magicTrees, skillTrees, updatePlayerSprite };
+export { player, playerSpriteKey, updatePlayerSprite };
 export { stats, inventory, progression };

--- a/modules/playerProgression.js
+++ b/modules/playerProgression.js
@@ -1,3 +1,15 @@
+import { skillTrees } from './skillTrees.js';
+
+// Initialize unlocked skill arrays for a given class
+function initSkills(cls){
+  const res={};
+  const trees=skillTrees[cls];
+  for(const key in trees){
+    res[key]=new Array(trees[key].abilities.length).fill(false);
+  }
+  return res;
+}
+
 // Player progression such as level and experience.
 class PlayerProgression {
   constructor() {
@@ -11,8 +23,7 @@ class PlayerProgression {
     this.timeSurvived = 0;
     this.floorsCleared = 0;
     this.class = 'warrior';
-    this.magic = { healing:[false,false,false,false,false,false], damage:[false,false,false,false,false,false], dot:[false,false,false,false,false,false] };
-    this.skills = { offense:[false,false,false,false,false,false], defense:[false,false,false,false,false,false], techniques:[false,false,false], tricks:[false,false,false] };
+    this.skills = initSkills(this.class);
     this.boundSpell = null;
     this.boundSkill = null;
   }

--- a/modules/skillTrees.js
+++ b/modules/skillTrees.js
@@ -1,0 +1,83 @@
+// Defines class-specific skill trees based on popular RPG examples.
+const skillTrees = {
+  warrior: {
+    arms: {
+      display: 'Arms',
+      abilities: [
+        { name: 'Mortal Strike', desc: 'A powerful strike dealing extra damage.', bonus: { dmgMin: 3, dmgMax: 3 }, cost: 1 },
+        { name: 'Slam', desc: 'Heavy blow that further increases damage.', bonus: { dmgMin: 5, dmgMax: 5 }, cost: 2 },
+        { name: 'Rend', desc: 'Bleed the target for damage over time.', cast: 'rend', cost: 3 }
+      ]
+    },
+    fury: {
+      display: 'Fury',
+      abilities: [
+        { name: 'Enrage', desc: 'Increase attack speed by 10%.', bonus: { atkSpd: 10 }, cost: 1 },
+        { name: 'Bloodthirst', desc: 'A brutal attack that heals you for part of the damage dealt.', cast: 'bloodthirst', cost: 2 },
+        { name: 'Whirlwind', desc: 'Spin and strike nearby foes.', cast: 'whirlwind', cost: 3 }
+      ]
+    },
+    protection: {
+      display: 'Protection',
+      abilities: [
+        { name: 'Shield Block', desc: 'Increase armor significantly.', bonus: { armor: 3 }, cost: 1 },
+        { name: 'Last Stand', desc: 'Temporarily gain bonus health.', cast: 'lastStand', cost: 2 },
+        { name: 'Defensive Stance', desc: 'Reduce damage taken.', bonus: { dmgReduction: 10 }, cost: 3 }
+      ]
+    }
+  },
+  mage: {
+    fire: {
+      display: 'Fire',
+      abilities: [
+        { name: 'Fireball', type: 'damage', dmg: 25, mp: 10, cost: 1, range: 8, elem: 'fire', status: { k: 'burn', dur: 2000, power: 1.0, chance: 1 } },
+        { name: 'Flamestrike', type: 'damage', dmg: 45, mp: 20, cost: 2, range: 8, elem: 'fire', status: { k: 'burn', dur: 3000, power: 1.2, chance: 1 } },
+        { name: 'Pyroblast', type: 'damage', dmg: 70, mp: 30, cost: 3, range: 9, elem: 'fire', status: { k: 'burn', dur: 4000, power: 1.4, chance: 1 } }
+      ]
+    },
+    frost: {
+      display: 'Frost',
+      abilities: [
+        { name: 'Frostbolt', type: 'damage', dmg: 20, mp: 8, cost: 1, range: 8, elem: 'ice', status: { k: 'freeze', dur: 1800, power: 0.4, chance: 1 } },
+        { name: 'Ice Lance', type: 'damage', dmg: 35, mp: 15, cost: 2, range: 8, elem: 'ice', status: { k: 'freeze', dur: 2000, power: 0.5, chance: 1 } },
+        { name: 'Blizzard', type: 'damage', dmg: 55, mp: 25, cost: 3, range: 9, elem: 'ice', status: { k: 'freeze', dur: 3000, power: 0.6, chance: 1 } }
+      ]
+    },
+    arcane: {
+      display: 'Arcane',
+      abilities: [
+        { name: 'Arcane Missiles', type: 'damage', dmg: 30, mp: 12, cost: 1, range: 8, elem: 'magic' },
+        { name: 'Arcane Explosion', type: 'damage', dmg: 50, mp: 20, cost: 2, range: 7, elem: 'magic' },
+        { name: 'Arcane Power', desc: 'Increase magic damage by 20% for a short time.', cast: 'arcanePower', cost: 3 }
+      ]
+    }
+  },
+  rogue: {
+    assassination: {
+      display: 'Assassination',
+      abilities: [
+        { name: 'Backstab', desc: 'Strike from behind for extra damage.', cast: 'backstab', cost: 1 },
+        { name: 'Poison Strike', desc: 'Coat your weapon with poison for extra damage over time.', cast: 'poisonStrike', cost: 2 },
+        { name: 'Mutilate', desc: 'Dual strike causing heavy damage.', cast: 'mutilate', cost: 3 }
+      ]
+    },
+    combat: {
+      display: 'Combat',
+      abilities: [
+        { name: 'Sinister Strike', desc: 'A vicious melee attack.', cast: 'sinisterStrike', cost: 1 },
+        { name: 'Blade Flurry', desc: 'Attack two nearby enemies at once.', cast: 'bladeFlurry', cost: 2 },
+        { name: 'Adrenaline Rush', desc: 'Temporarily increases attack speed.', cast: 'adrenalineRush', cost: 3 }
+      ]
+    },
+    subtlety: {
+      display: 'Subtlety',
+      abilities: [
+        { name: 'Stealth', desc: 'Become invisible to enemies.', cast: 'stealth', cost: 1 },
+        { name: 'Shadowstep', desc: 'Teleport behind an enemy.', cast: 'shadowstep', cost: 2 },
+        { name: 'Vanish', desc: 'Disappear from sight, dropping enemy attention.', cast: 'vanish', cost: 3 }
+      ]
+    }
+  }
+};
+
+export { skillTrees };

--- a/test/rogue-skills.test.js
+++ b/test/rogue-skills.test.js
@@ -1,20 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { skillTrees } from '../modules/player.js';
+import { skillTrees } from '../modules/skillTrees.js';
 
-test('Poison Strike ability defined in rogue tricks skill tree', () => {
-  const tricks = skillTrees.tricks;
-  assert.ok(tricks, 'tricks skill tree exists');
-  const ability = tricks.abilities.find(ab => ab.name === 'Poison Strike');
+test('Poison Strike ability defined in rogue assassination skill tree', () => {
+  const assassination = skillTrees.rogue.assassination;
+  assert.ok(assassination, 'assassination skill tree exists');
+  const ability = assassination.abilities.find(ab => ab.name === 'Poison Strike');
   assert.ok(ability, 'Poison Strike ability present');
   assert.equal(ability.cast, 'poisonStrike');
   assert.equal(ability.cost, 2);
 });
 
-test('Vanish ability defined in rogue tricks skill tree', () => {
-  const tricks = skillTrees.tricks;
-  assert.ok(tricks, 'tricks skill tree exists');
-  const ability = tricks.abilities.find(ab => ab.name === 'Vanish');
+test('Vanish ability defined in rogue subtlety skill tree', () => {
+  const subtlety = skillTrees.rogue.subtlety;
+  assert.ok(subtlety, 'subtlety skill tree exists');
+  const ability = subtlety.abilities.find(ab => ab.name === 'Vanish');
   assert.ok(ability, 'Vanish ability present');
   assert.equal(ability.cast, 'vanish');
   assert.equal(ability.cost, 3);

--- a/test/warrior-mage-skills.test.js
+++ b/test/warrior-mage-skills.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { skillTrees } from '../modules/skillTrees.js';
+
+test('Mortal Strike ability defined in warrior arms skill tree', () => {
+  const arms = skillTrees.warrior.arms;
+  assert.ok(arms, 'arms skill tree exists');
+  const ability = arms.abilities.find(ab => ab.name === 'Mortal Strike');
+  assert.ok(ability, 'Mortal Strike ability present');
+  assert.equal(ability.cost, 1);
+});
+
+test('Arcane Missiles ability defined in mage arcane skill tree', () => {
+  const arcane = skillTrees.mage.arcane;
+  assert.ok(arcane, 'arcane skill tree exists');
+  const ability = arcane.abilities.find(ab => ab.name === 'Arcane Missiles');
+  assert.ok(ability, 'Arcane Missiles ability present');
+  assert.equal(ability.cost, 1);
+});


### PR DESCRIPTION
## Summary
- import skill tree definitions directly in game logic
- decouple player module from skill tree exports
- add tests verifying warrior and mage skill trees

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ed736a8c8322b7df1324f130affc