### PR TITLE
Implement class-based skill tree structure

### DIFF
--- a/modules/player.js
+++ b/modules/player.js
@@ -21,78 +21,97 @@ Object.assign(player, stats, inventory, progression);
 
 let playerSpriteKey = 'player_warrior';
 
-const magicTrees={
-  healing:{display:'Healing',abilities:[
-    {name:'Heal I',type:'heal',value:30,mp:10,cost:1},
-    {name:'Heal II',type:'heal',value:60,mp:20,cost:2},
-    {name:'Heal III',type:'heal',value:120,mp:30,cost:3},
-    {name:'Heal IV',type:'heal',value:null,mp:40,cost:4},
-    {name:'Heal V',type:'heal',value:null,mp:60,cost:5},
-    {name:'Divine Light',type:'heal',value:null,mp:80,cost:9}
-  ]},
-  damage:{display:'Damage',abilities:[
-    {name:'Fire Bolt',type:'damage',dmg:15,mp:10,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2000,power:1.0,chance:1}},
-    {name:'Ice Spike',type:'damage',dmg:40,mp:15,cost:2,range:8,elem:'ice',status:{k:'freeze',dur:1800,power:0.4,chance:1}},
-    {name:'Lightning Bolt',type:'damage',dmg:65,mp:20,cost:3,range:9,elem:'shock',status:{k:'shock',dur:2000,power:0.25,chance:1}},
-    {name:'Arcane Blast',type:'damage',dmg:90,mp:30,cost:4,range:9,elem:'magic'},
-    {name:'Meteor',type:'damage',dmg:120,mp:40,cost:5,range:9,elem:'fire',status:{k:'burn',dur:3000,power:1.5,chance:1}},
-    {name:'Void Ray',type:'damage',dmg:150,mp:60,cost:9,range:10,elem:'magic'}
-  ]},
-  dot:{display:'Damage Over Time',abilities:[
-    {name:'Ignite',type:'dot',dmg:8,mp:12,cost:1,range:8,elem:'fire',status:{k:'burn',dur:2200,power:1.0,chance:1}},
-    {name:'Scorch',type:'dot',dmg:18,mp:16,cost:2,range:8,elem:'fire',status:{k:'burn',dur:2600,power:1.1,chance:1}},
-    {name:'Sear',type:'dot',dmg:28,mp:20,cost:3,range:8,elem:'fire',status:{k:'burn',dur:3000,power:1.2,chance:1}},
-    {name:'Inferno',type:'dot',dmg:38,mp:25,cost:4,range:8,elem:'fire',status:{k:'burn',dur:3400,power:1.3,chance:1}},
-    {name:'Conflagrate',type:'dot',dmg:48,mp:28,cost:5,range:8,elem:'fire',status:{k:'burn',dur:3800,power:1.4,chance:1}},
-    {name:'Hellfire',type:'dot',dmg:60,mp:35,cost:9,range:8,elem:'fire',status:{k:'burn',dur:4200,power:1.5,chance:1}}
-  ]}
+// Generic node factory for skill tree creation
+function node(data, children = []) {
+  return { ...data, children };
+}
+
+const skillTrees = {
+  warrior: node({ name: 'Warrior' }, [
+    node({ name: 'Precision', desc: 'Increase critical chance by 5%.', bonus: { crit: 5 }, cost: 1 }, [
+      node({ name: 'Berserk', desc: 'Increase attack damage by 2.', bonus: { dmgMin: 2, dmgMax: 2 }, cost: 2 }, [
+        node({ name: 'Cleave', desc: 'Increase attack damage by 3.', bonus: { dmgMin: 3, dmgMax: 3 }, cost: 3 }, [
+          node({ name: 'Earthshatter', desc: 'Increase attack damage by 4.', bonus: { dmgMin: 4, dmgMax: 4 }, cost: 4 }, [
+            node({ name: 'Bloodlust', desc: 'Increase attack damage by 5.', bonus: { dmgMin: 5, dmgMax: 5 }, cost: 5 }, [
+              node({ name: 'Dominance', desc: 'Increase attack damage by 6.', bonus: { dmgMin: 6, dmgMax: 6 }, cost: 9 })
+            ])
+          ])
+        ])
+      ])
+    ]),
+    node({ name: 'Toughness', desc: 'Increase max HP by 20.', bonus: { hpMax: 20 }, cost: 1 }, [
+      node({ name: 'Shield Wall', desc: 'Increase armor by 4.', bonus: { armor: 4 }, cost: 2 }, [
+        node({ name: 'Fortify', desc: 'Increase max HP by 20.', bonus: { hpMax: 20 }, cost: 3 }, [
+          node({ name: 'Stone Skin', desc: 'Increase armor by 4.', bonus: { armor: 4 }, cost: 4 }, [
+            node({ name: 'Guardian', desc: 'Increase max HP by 30.', bonus: { hpMax: 30 }, cost: 5 }, [
+              node({ name: 'Unbreakable', desc: 'Increase armor by 6.', bonus: { armor: 6 }, cost: 7 }, [
+                node({ name: 'Bulwark', desc: 'Increase armor by 15%.', bonus: { armorPct: 15 }, cost: 9 })
+              ])
+            ])
+          ])
+        ])
+      ])
+    ]),
+    node({ name: 'Power Strike', desc: 'Spend 20 stamina to strike for 40% more damage.', cost: 1, cast: 'powerStrike' }, [
+      node({ name: 'Whirlwind', desc: 'Spin and hit nearby foes for 60% more damage (30 stamina).', cost: 2, cast: 'whirlwind' }, [
+        node({ name: 'Shield Bash', desc: 'Bash an enemy for 80% more damage and shock them (15 stamina).', cost: 3, cast: 'shieldBash' })
+      ])
+    ])
+  ]),
+
+  mage: node({ name: 'Mage' }, [
+    node({ name: 'Heal I', type: 'heal', value: 30, mp: 10, cost: 1 }, [
+      node({ name: 'Heal II', type: 'heal', value: 60, mp: 20, cost: 2 }, [
+        node({ name: 'Heal III', type: 'heal', value: 120, mp: 30, cost: 3 }, [
+          node({ name: 'Heal IV', type: 'heal', value: null, mp: 40, cost: 4 }, [
+            node({ name: 'Heal V', type: 'heal', value: null, mp: 60, cost: 5 }, [
+              node({ name: 'Divine Light', type: 'heal', value: null, mp: 80, cost: 9 })
+            ])
+          ])
+        ])
+      ])
+    ]),
+    node({ name: 'Fire Bolt', type: 'damage', dmg: 15, mp: 10, cost: 1, range: 8, elem: 'fire', status: { k: 'burn', dur: 2000, power: 1.0, chance: 1 } }, [
+      node({ name: 'Ice Spike', type: 'damage', dmg: 40, mp: 15, cost: 2, range: 8, elem: 'ice', status: { k: 'freeze', dur: 1800, power: 0.4, chance: 1 } }, [
+        node({ name: 'Lightning Bolt', type: 'damage', dmg: 65, mp: 20, cost: 3, range: 9, elem: 'shock', status: { k: 'shock', dur: 2000, power: 0.25, chance: 1 } }, [
+          node({ name: 'Arcane Blast', type: 'damage', dmg: 90, mp: 30, cost: 4, range: 9, elem: 'magic' }, [
+            node({ name: 'Meteor', type: 'damage', dmg: 120, mp: 40, cost: 5, range: 9, elem: 'fire', status: { k: 'burn', dur: 3000, power: 1.5, chance: 1 } }, [
+              node({ name: 'Void Ray', type: 'damage', dmg: 150, mp: 60, cost: 9, range: 10, elem: 'magic' })
+            ])
+          ])
+        ])
+      ])
+    ]),
+    node({ name: 'Ignite', type: 'dot', dmg: 8, mp: 12, cost: 1, range: 8, elem: 'fire', status: { k: 'burn', dur: 2200, power: 1.0, chance: 1 } }, [
+      node({ name: 'Scorch', type: 'dot', dmg: 18, mp: 16, cost: 2, range: 8, elem: 'fire', status: { k: 'burn', dur: 2600, power: 1.1, chance: 1 } }, [
+        node({ name: 'Sear', type: 'dot', dmg: 28, mp: 20, cost: 3, range: 8, elem: 'fire', status: { k: 'burn', dur: 3000, power: 1.2, chance: 1 } }, [
+          node({ name: 'Inferno', type: 'dot', dmg: 38, mp: 25, cost: 4, range: 8, elem: 'fire', status: { k: 'burn', dur: 3400, power: 1.3, chance: 1 } }, [
+            node({ name: 'Conflagrate', type: 'dot', dmg: 48, mp: 28, cost: 5, range: 8, elem: 'fire', status: { k: 'burn', dur: 3800, power: 1.4, chance: 1 } }, [
+              node({ name: 'Hellfire', type: 'dot', dmg: 60, mp: 35, cost: 9, range: 8, elem: 'fire', status: { k: 'burn', dur: 4200, power: 1.5, chance: 1 } })
+            ])
+          ])
+        ])
+      ])
+    ])
+  ]),
+
+  rogue: node({ name: 'Rogue' }, [
+    node({ name: 'Deadly Precision', desc: 'Increase critical chance by 10%.', bonus: { crit: 10 }, cost: 1 }, [
+      node({ name: 'Poison Strike', desc: 'Spend 20 stamina to strike and poison an enemy.', cost: 2, cast: 'poisonStrike' }),
+      node({ name: 'Vanish', desc: 'Spend 25 stamina to become invisible for 4 seconds.', cost: 3, cast: 'vanish' })
+    ])
+  ])
 };
 
-const skillTrees={
-  offense:{display:'Offense',abilities:[
-    {name:'Precision',desc:'Increase critical chance by 5%.',bonus:{crit:5},cost:1},
-    {name:'Berserk',desc:'Increase attack damage by 2.',bonus:{dmgMin:2,dmgMax:2},cost:2},
-    {name:'Cleave',desc:'Increase attack damage by 3.',bonus:{dmgMin:3,dmgMax:3},cost:3},
-    {name:'Earthshatter',desc:'Increase attack damage by 4.',bonus:{dmgMin:4,dmgMax:4},cost:4},
-    {name:'Bloodlust',desc:'Increase attack damage by 5.',bonus:{dmgMin:5,dmgMax:5},cost:5},
-    {name:'Dominance',desc:'Increase attack damage by 6.',bonus:{dmgMin:6,dmgMax:6},cost:9}
-  ]},
-  defense:{display:'Defense',abilities:[
-    {name:'Toughness',desc:'Increase max HP by 20.',bonus:{hpMax:20},cost:1},
-    {name:'Shield Wall',desc:'Increase armor by 4.',bonus:{armor:4},cost:2},
-    {name:'Fortify',desc:'Increase max HP by 20.',bonus:{hpMax:20},cost:3},
-    {name:'Stone Skin',desc:'Increase armor by 4.',bonus:{armor:4},cost:4},
-    {name:'Guardian',desc:'Increase max HP by 30.',bonus:{hpMax:30},cost:5},
-    {name:'Unbreakable',desc:'Increase armor by 6.',bonus:{armor:6},cost:7},
-    {name:'Bulwark',desc:'Increase armor by 15%.',bonus:{armorPct:15},cost:9}
-  ]},
-  techniques:{display:'Techniques',class:'warrior',abilities:[
-    {name:'Power Strike',desc:'Spend 20 stamina to strike for 40% more damage.',cost:1,cast:'powerStrike'},
-    {name:'Whirlwind',desc:'Spin and hit nearby foes for 60% more damage (30 stamina).',cost:2,cast:'whirlwind'},
-    {name:'Shield Bash',desc:'Bash an enemy for 80% more damage and shock them (15 stamina).',cost:3,cast:'shieldBash'}
-  ]},
-  tricks:{display:'Tricks',class:'rogue',abilities:[
-    {name:'Deadly Precision',desc:'Increase critical chance by 10%.',bonus:{crit:10},cost:1},
-    {name:'Poison Strike',desc:'Spend 20 stamina to strike and poison an enemy.',cost:2,cast:'poisonStrike'},
-    {name:'Vanish',desc:'Spend 25 stamina to become invisible for 4 seconds.',cost:3,cast:'vanish'}
-  ]}
-};
-
-function updatePlayerSprite(){
-  if(player.class==='mage'){
-    let elem='magic';
-    if(player.boundSpell){
-      const ab=magicTrees[player.boundSpell.tree].abilities[player.boundSpell.idx];
-      elem = ab.elem || 'magic';
-    }
-    const key = elem==='magic' ? 'player_mage' : `player_mage_${elem}`;
-    playerSpriteKey = ASSETS.sprites[key] ? key : 'player_mage';
-  }else if(player.class==='rogue'){
-    playerSpriteKey='player_rogue';
-  }else{
-    playerSpriteKey='player_warrior';
+function updatePlayerSprite() {
+  if (player.class === 'mage') {
+    playerSpriteKey = 'player_mage';
+  } else if (player.class === 'rogue') {
+    playerSpriteKey = 'player_rogue';
+  } else {
+    playerSpriteKey = 'player_warrior';
   }
 }
 
-export { player, playerSpriteKey, magicTrees, skillTrees, updatePlayerSprite };
+export { player, playerSpriteKey, skillTrees, updatePlayerSprite };
 export { stats, inventory, progression };

--- a/modules/playerProgression.js
+++ b/modules/playerProgression.js
@@ -11,8 +11,8 @@ class PlayerProgression {
     this.timeSurvived = 0;
     this.floorsCleared = 0;
     this.class = 'warrior';
-    this.magic = { healing:[false,false,false,false,false,false], damage:[false,false,false,false,false,false], dot:[false,false,false,false,false,false] };
-    this.skills = { offense:[false,false,false,false,false,false], defense:[false,false,false,false,false,false,false], techniques:[false,false,false], tricks:[false,false,false] };
+    // skill tree will be populated with class-specific structure
+    this.skillTree = null;
     this.boundSpell = null;
     this.boundSkill = null;
   }

--- a/test/rogue-skills.test.js
+++ b/test/rogue-skills.test.js
@@ -2,19 +2,28 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { skillTrees } from '../modules/player.js';
 
-test('Poison Strike ability defined in rogue tricks skill tree', () => {
-  const tricks = skillTrees.tricks;
-  assert.ok(tricks, 'tricks skill tree exists');
-  const ability = tricks.abilities.find(ab => ab.name === 'Poison Strike');
+function findNode(node, name) {
+  if (node.name === name) return node;
+  for (const child of node.children || []) {
+    const found = findNode(child, name);
+    if (found) return found;
+  }
+  return null;
+}
+
+test('Poison Strike ability defined in rogue skill tree', () => {
+  const rogue = skillTrees.rogue;
+  assert.ok(rogue, 'rogue skill tree exists');
+  const ability = findNode(rogue, 'Poison Strike');
   assert.ok(ability, 'Poison Strike ability present');
   assert.equal(ability.cast, 'poisonStrike');
   assert.equal(ability.cost, 2);
 });
 
-test('Vanish ability defined in rogue tricks skill tree', () => {
-  const tricks = skillTrees.tricks;
-  assert.ok(tricks, 'tricks skill tree exists');
-  const ability = tricks.abilities.find(ab => ab.name === 'Vanish');
+test('Vanish ability defined in rogue skill tree', () => {
+  const rogue = skillTrees.rogue;
+  assert.ok(rogue, 'rogue skill tree exists');
+  const ability = findNode(rogue, 'Vanish');
   assert.ok(ability, 'Vanish ability present');
   assert.equal(ability.cast, 'vanish');
   assert.equal(ability.cost, 3);


### PR DESCRIPTION
## Summary
- Rework player modules to use hierarchical skill trees for warrior, mage, and rogue
- Track a unified skill tree in player progression
- Update tests to traverse new skill tree structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f22b35888322b2cdb278f7048d22