### PR TITLE
Fix missing magic tree exports preventing game launch

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,6 @@
 import { initAudio, playFootstep, playAttack, playHit, playCalmMusic, playCombatMusic, playBossMusic } from './modules/audio.js';
 import { keys, initInput } from './modules/input.js';
-import { player, playerSpriteKey, magicTrees, skillTrees, updatePlayerSprite } from './modules/player.js';
+import { player, playerSpriteKey, magicTrees, skillTreesFlat as skillTrees, updatePlayerSprite } from './modules/player.js';
 import { inventory, SLOTS, BAG_SIZE, POTION_BAG_SIZE } from './modules/playerInventory.js';
 import { hpFill, mpFill, hpLbl, mpLbl, hudFloor, hudSeed, hudGold, hudDmg, hudScore, hudKills, xpFill, xpLbl, hudLvl, hudSpell, hudAbilityLabel, updateResourceUI, updateXPUI, updateScoreUI, toggleActionLog, showToast, showBossAlert, showRespawn } from './modules/ui.js';
 import { TILE, MAP_W, MAP_H, T_EMPTY, T_FLOOR, T_WALL, T_TRAP, T_LAVA, TRAP_CHANCE, LAVA_CHANCE, map, fog, vis, rooms, stairs, merchant, merchantStyle, torches, lavaTiles, spikeTraps, walkable, canMoveFrom, resetMapState } from './modules/map.js';

--- a/modules/player.js
+++ b/modules/player.js
@@ -23,12 +23,12 @@ Object.assign(player, stats, inventory, progression);
 
 let playerSpriteKey = 'player_warrior';
 
-// Generic node factory for skill tree creation
+// ===== Skill tree node definitions (nested structure used in tests) =====
 function node(data, children = []) {
   return { ...data, children };
 }
 
-const skillTrees = {
+const skillTreeNodes = {
   warrior: node({ name: 'Berserker' }, [
     node({ name: 'Battle Instinct', desc: 'Increase critical chance by 5%.', bonus: { crit: 5 }, cost: 1 }, [
       node({ name: 'Frenzied Blows', desc: 'Increase attack damage by 2.', bonus: { dmgMin: 2, dmgMax: 2 }, cost: 2 }, [
@@ -105,6 +105,91 @@ const skillTrees = {
   ])
 };
 
+// ===== Magic trees (used by the mage class) =====
+const magicTrees = {
+  healing: {
+    display: 'Healing',
+    abilities: [
+      { name: 'Minor Mend', type: 'heal', value: 30, mp: 10, cost: 1 },
+      { name: 'Major Mend', type: 'heal', value: 60, mp: 20, cost: 2 },
+      { name: 'Greater Mend', type: 'heal', value: 120, mp: 30, cost: 3 },
+      { name: 'Arcane Renewal', type: 'heal', value: null, mp: 40, cost: 4 },
+      { name: 'Mystic Restoration', type: 'heal', value: null, mp: 60, cost: 5 },
+      { name: 'Celestial Radiance', type: 'heal', value: null, mp: 80, cost: 9 }
+    ]
+  },
+  damage: {
+    display: 'Damage',
+    abilities: [
+      { name: 'Flame Bolt', type: 'damage', dmg: 15, mp: 10, cost: 1, range: 8, elem: 'fire', status: { k: 'burn', dur: 2000, power: 1.0, chance: 1 } },
+      { name: 'Frost Spike', type: 'damage', dmg: 40, mp: 15, cost: 2, range: 8, elem: 'ice', status: { k: 'freeze', dur: 1800, power: 0.4, chance: 1 } },
+      { name: 'Storm Bolt', type: 'damage', dmg: 65, mp: 20, cost: 3, range: 9, elem: 'shock', status: { k: 'shock', dur: 2000, power: 0.25, chance: 1 } },
+      { name: 'Arcane Burst', type: 'damage', dmg: 90, mp: 30, cost: 4, range: 9, elem: 'magic' },
+      { name: 'Falling Star', type: 'damage', dmg: 120, mp: 40, cost: 5, range: 9, elem: 'fire', status: { k: 'burn', dur: 3000, power: 1.5, chance: 1 } },
+      { name: 'Astral Ray', type: 'damage', dmg: 150, mp: 60, cost: 9, range: 10, elem: 'magic' }
+    ]
+  },
+  dot: {
+    display: 'Damage over Time',
+    abilities: [
+      { name: 'Spark', type: 'dot', dmg: 8, mp: 12, cost: 1, range: 8, elem: 'fire', status: { k: 'burn', dur: 2200, power: 1.0, chance: 1 } },
+      { name: 'Ember', type: 'dot', dmg: 18, mp: 16, cost: 2, range: 8, elem: 'fire', status: { k: 'burn', dur: 2600, power: 1.1, chance: 1 } },
+      { name: 'Blaze', type: 'dot', dmg: 28, mp: 20, cost: 3, range: 8, elem: 'fire', status: { k: 'burn', dur: 3000, power: 1.2, chance: 1 } },
+      { name: 'Wildfire', type: 'dot', dmg: 38, mp: 25, cost: 4, range: 8, elem: 'fire', status: { k: 'burn', dur: 3400, power: 1.3, chance: 1 } },
+      { name: 'Firestorm', type: 'dot', dmg: 48, mp: 28, cost: 5, range: 8, elem: 'fire', status: { k: 'burn', dur: 3800, power: 1.4, chance: 1 } },
+      { name: 'Cataclysm', type: 'dot', dmg: 60, mp: 35, cost: 9, range: 8, elem: 'fire', status: { k: 'burn', dur: 4200, power: 1.5, chance: 1 } }
+    ]
+  }
+};
+
+// ===== Skill trees (used by warrior and rogue) =====
+const flatSkillTrees = {
+  warrior: {
+    name: 'Berserker',
+    class: 'warrior',
+    display: 'Warrior Skills',
+    abilities: [
+      { name: 'Battle Instinct', desc: 'Increase critical chance by 5%.', bonus: { crit: 5 }, cost: 1 },
+      { name: 'Frenzied Blows', desc: 'Increase attack damage by 2.', bonus: { dmgMin: 2, dmgMax: 2 }, cost: 2 },
+      { name: 'Crushing Swing', desc: 'Increase attack damage by 3.', bonus: { dmgMin: 3, dmgMax: 3 }, cost: 3 },
+      { name: 'Earthshaker', desc: 'Increase attack damage by 4.', bonus: { dmgMin: 4, dmgMax: 4 }, cost: 4 },
+      { name: 'Bloodthirst', desc: 'Increase attack damage by 5.', bonus: { dmgMin: 5, dmgMax: 5 }, cost: 5 },
+      { name: 'Overwhelm', desc: 'Increase attack damage by 6.', bonus: { dmgMin: 6, dmgMax: 6 }, cost: 9 },
+      { name: 'Endurance', desc: 'Increase max HP by 20.', bonus: { hpMax: 20 }, cost: 1 },
+      { name: 'Iron Wall', desc: 'Increase armor by 4.', bonus: { armor: 4 }, cost: 2 },
+      { name: 'Stone Guard', desc: 'Increase max HP by 20.', bonus: { hpMax: 20 }, cost: 3 },
+      { name: 'Plate Skin', desc: 'Increase armor by 4.', bonus: { armor: 4 }, cost: 4 },
+      { name: 'Sentinel', desc: 'Increase max HP by 30.', bonus: { hpMax: 30 }, cost: 5 },
+      { name: 'Unyielding', desc: 'Increase armor by 6.', bonus: { armor: 6 }, cost: 7 },
+      { name: 'Aegis', desc: 'Increase armor by 15%.', bonus: { armorPct: 15 }, cost: 9 },
+      { name: 'Raging Strike', desc: 'Spend 20 stamina to strike for 40% more damage.', cost: 1, cast: 'powerStrike' },
+      { name: 'Blade Cyclone', desc: 'Spin and hit nearby foes for 60% more damage (30 stamina).', cost: 2, cast: 'whirlwind' },
+      { name: 'Thunder Bash', desc: 'Bash an enemy for 80% more damage and shock them (15 stamina).', cost: 3, cast: 'shieldBash' }
+    ]
+  },
+  rogue: {
+    name: 'Nightblade',
+    class: 'rogue',
+    display: 'Rogue Skills',
+    abilities: [
+      { name: 'Keen Aim', desc: 'Increase critical chance by 10%.', bonus: { crit: 10 }, cost: 1 },
+      { name: 'Venom Slash', desc: 'Spend 20 stamina to strike and poison an enemy.', cost: 2, cast: 'poisonStrike' },
+      { name: 'Shadowmeld', desc: 'Spend 25 stamina to become invisible for 4 seconds.', cost: 3, cast: 'vanish' }
+    ]
+  }
+};
+
+// Initialise skill/magic unlock tracking on the player
+player.skills = {
+  warrior: new Array(flatSkillTrees.warrior.abilities.length).fill(false),
+  rogue: new Array(flatSkillTrees.rogue.abilities.length).fill(false)
+};
+player.magic = {
+  healing: new Array(magicTrees.healing.abilities.length).fill(false),
+  damage: new Array(magicTrees.damage.abilities.length).fill(false),
+  dot: new Array(magicTrees.dot.abilities.length).fill(false)
+};
+
 function updatePlayerSprite() {
   if (player.class === 'mage') {
     playerSpriteKey = 'player_mage';
@@ -115,5 +200,5 @@ function updatePlayerSprite() {
   }
 }
 
-export { player, playerSpriteKey, skillTrees, updatePlayerSprite };
+export { player, playerSpriteKey, magicTrees, flatSkillTrees as skillTreesFlat, skillTreeNodes as skillTrees, updatePlayerSprite };
 export { stats, inventory, progression };


### PR DESCRIPTION
## Summary
- add explicit magic and skill trees with ability data
- initialise player skill and spell unlock tracking
- adjust game import to use flattened skill tree data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b11dbf91f883229ffa1744227bb16b