### PR TITLE
Add example skill tree module

### DIFF
--- a/modules/simpleSkillTree.js
+++ b/modules/simpleSkillTree.js
@@ -1,0 +1,54 @@
+// Simple skill tree example with three branches: attack, defence and utility.
+// Each branch is a small linear tree where unlocking a child requires the parent.
+
+// Generic node factory for building tree nodes.
+function node(data, children = []) {
+  return { ...data, children };
+}
+
+// Convenience helper to flatten a branch into a linear list. This mirrors the
+// approach used in player.js so it can be consumed by existing UI code.
+function flattenBranch(branch) {
+  const abilities = [];
+  (function traverse(n, parent = -1) {
+    const { children = [], ...data } = n;
+    const idx = abilities.length;
+    abilities.push({ ...data, parent });
+    children.forEach(child => traverse(child, idx));
+  })(branch);
+  return abilities;
+}
+
+// Define the simple skill tree structure.
+const simpleSkillTreeGraph = {
+  attack: node({ name: 'Attack' }, [
+    node({ name: 'Quick Jab', desc: 'Increase attack speed by 5%.', bonus: { atkSpd: 5 }, cost: 1 }, [
+      node({ name: 'Heavy Swing', desc: 'Increase damage by 10%.', bonus: { dmgPct: 10 }, cost: 2 }, [
+        node({ name: 'Overpower', desc: 'Critical hits deal 20% more damage.', bonus: { critDmg: 20 }, cost: 3 })
+      ])
+    ])
+  ]),
+  defence: node({ name: 'Defence' }, [
+    node({ name: 'Toughness', desc: 'Increase max HP by 10%.', bonus: { hpPct: 10 }, cost: 1 }, [
+      node({ name: 'Iron Will', desc: 'Reduce damage taken by 5%.', bonus: { dmgRed: 5 }, cost: 2 }, [
+        node({ name: 'Guardian', desc: 'Increase armor by 10%.', bonus: { armorPct: 10 }, cost: 3 })
+      ])
+    ])
+  ]),
+  utility: node({ name: 'Utility' }, [
+    node({ name: 'Fleet Foot', desc: 'Increase movement speed by 5%.', bonus: { speedPct: 5 }, cost: 1 }, [
+      node({ name: 'Adrenaline', desc: 'Regenerate 1 stamina per second.', bonus: { stamRegen: 1 }, cost: 2 }, [
+        node({ name: 'Evasion', desc: 'Increase dodge chance by 5%.', bonus: { dodge: 5 }, cost: 3 })
+      ])
+    ])
+  ])
+};
+
+// Export a flattened representation for easy consumption.
+const simpleSkillTrees = {
+  attack: { display: 'Attack', abilities: flattenBranch(simpleSkillTreeGraph.attack) },
+  defence: { display: 'Defence', abilities: flattenBranch(simpleSkillTreeGraph.defence) },
+  utility: { display: 'Utility', abilities: flattenBranch(simpleSkillTreeGraph.utility) }
+};
+
+export { simpleSkillTreeGraph, simpleSkillTrees, node, flattenBranch };

--- a/test/simple-skill-tree.test.js
+++ b/test/simple-skill-tree.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { simpleSkillTreeGraph } from '../modules/simpleSkillTree.js';
+
+test('simple attack branch has linear progression', () => {
+  const attack = simpleSkillTreeGraph.attack;
+  assert.equal(attack.children[0].name, 'Quick Jab');
+  assert.equal(attack.children[0].children[0].name, 'Heavy Swing');
+});
+
+test('simple defence branch ends with Guardian ability', () => {
+  const defence = simpleSkillTreeGraph.defence;
+  const guardian = defence.children[0].children[0].children[0];
+  assert.equal(guardian.name, 'Guardian');
+  assert.equal(guardian.bonus.armorPct, 10);
+});


### PR DESCRIPTION
## Summary
- add simple skill tree module with attack, defence and utility branches
- include tests covering new skill graph

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1286a14448322ae2108aaddd27139