### PR TITLE
Refine simple skill tree flattening

### DIFF
--- a/modules/simpleSkillTree.js
+++ b/modules/simpleSkillTree.js
@@ -44,11 +44,22 @@ const simpleSkillTreeGraph = {
   ])
 };
 
-// Export a flattened representation for easy consumption.
+// Export a flattened representation for easy consumption.  Each branch's
+// abilities array should start at the first unlockable skill rather than the
+// branch label itself, mirroring the structure used by the main game logic.
 const simpleSkillTrees = {
-  attack: { display: 'Attack', abilities: flattenBranch(simpleSkillTreeGraph.attack) },
-  defence: { display: 'Defence', abilities: flattenBranch(simpleSkillTreeGraph.defence) },
-  utility: { display: 'Utility', abilities: flattenBranch(simpleSkillTreeGraph.utility) }
+  attack: {
+    display: simpleSkillTreeGraph.attack.name,
+    abilities: flattenBranch(simpleSkillTreeGraph.attack.children[0])
+  },
+  defence: {
+    display: simpleSkillTreeGraph.defence.name,
+    abilities: flattenBranch(simpleSkillTreeGraph.defence.children[0])
+  },
+  utility: {
+    display: simpleSkillTreeGraph.utility.name,
+    abilities: flattenBranch(simpleSkillTreeGraph.utility.children[0])
+  }
 };
 
 export { simpleSkillTreeGraph, simpleSkillTrees, node, flattenBranch };

--- a/test/simple-skill-tree.test.js
+++ b/test/simple-skill-tree.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { simpleSkillTreeGraph } from '../modules/simpleSkillTree.js';
+import { simpleSkillTreeGraph, simpleSkillTrees } from '../modules/simpleSkillTree.js';
 
 test('simple attack branch has linear progression', () => {
   const attack = simpleSkillTreeGraph.attack;
@@ -13,4 +13,15 @@ test('simple defence branch ends with Guardian ability', () => {
   const guardian = defence.children[0].children[0].children[0];
   assert.equal(guardian.name, 'Guardian');
   assert.equal(guardian.bonus.armorPct, 10);
+});
+
+test('utility branch flattens into a linear ability list', () => {
+  const abilities = simpleSkillTrees.utility.abilities;
+  assert.deepEqual(
+    abilities.map(a => a.name),
+    ['Fleet Foot', 'Adrenaline', 'Evasion']
+  );
+  // Ensure parent indices link each ability sequentially
+  assert.equal(abilities[1].parent, 0);
+  assert.equal(abilities[2].parent, 1);
 });


### PR DESCRIPTION
## Summary
- ensure simple skill tree arrays begin with first unlockable ability
- test utility branch linear ordering and parent links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1297fa2548322aed9d6163108204b