### PR TITLE
Expand rogue skill tree with additional abilities

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,6 @@
 import { initAudio, playFootstep, playAttack, playHit, playCalmMusic, playCombatMusic, playBossMusic } from './modules/audio.js';
 import { keys, initInput } from './modules/input.js';
-import { player, playerSpriteKey, magicTrees, skillTrees, updatePlayerSprite } from './modules/player.js';
+import { player, playerSpriteKey, magicTrees, skillTrees, skillTreeGraph, updatePlayerSprite } from './modules/player.js';
 import { inventory, SLOTS, BAG_SIZE, POTION_BAG_SIZE } from './modules/playerInventory.js';
 import { hpFill, mpFill, hpLbl, mpLbl, hudFloor, hudSeed, hudGold, hudDmg, hudScore, hudKills, xpFill, xpLbl, hudLvl, hudSpell, hudAbilityLabel, updateResourceUI, updateXPUI, updateScoreUI, toggleActionLog, showToast, showBossAlert, showRespawn } from './modules/ui.js';
 import { TILE, MAP_W, MAP_H, T_EMPTY, T_FLOOR, T_WALL, T_TRAP, T_LAVA, TRAP_CHANCE, LAVA_CHANCE, map, fog, vis, rooms, stairs, merchant, merchantStyle, torches, lavaTiles, spikeTraps, walkable, canMoveFrom, resetMapState } from './modules/map.js';
@@ -1989,7 +1989,7 @@ function renderCharPage(){
   const panel=document.getElementById('charPage');
   if(!panel) return;
   let html='<div class="section-title">Character</div>';
-  html+=`<div class="kv">Class: <b>${skillTrees[player.class].name}</b></div>`;
+  html+=`<div class="kv">Class: <b>${skillTreeGraph[player.class].name}</b></div>`;
   html+=`<div class="kv">HP: <b>${player.hp}/${player.hpMax}</b></div>`;
   html+=`<div class="kv">${player.class==='mage'?'Mana':'Stamina'}: <b>${player.class==='mage'?player.mp+'/'+player.mpMax:player.sp+'/'+player.spMax}</b></div>`;
   html+=`<div class="kv">Attack: <b>${currentStats.dmgMin}-${currentStats.dmgMax}</b></div>`;

--- a/modules/player.js
+++ b/modules/player.js
@@ -100,8 +100,26 @@ const skillTreeGraph = {
 
   rogue: node({ name: 'Nightblade' }, [
     node({ name: 'Keen Aim', desc: 'Increase critical chance by 10%.', bonus: { crit: 10 }, cost: 1 }, [
-      node({ name: 'Venom Slash', desc: 'Spend 20 stamina to strike and poison an enemy.', cost: 2, cast: 'poisonStrike' }),
-      node({ name: 'Shadowmeld', desc: 'Spend 25 stamina to become invisible for 4 seconds.', cost: 3, cast: 'vanish' })
+      node({ name: 'Venom Slash', desc: 'Spend 20 stamina to strike and poison an enemy.', cost: 2, cast: 'poisonStrike' }, [
+        node({ name: 'Backstab', desc: 'Deal 50% more damage when striking from behind.', bonus: { backstab: 50 }, cost: 3 }, [
+          node({ name: 'Lethal Precision', desc: 'Increase critical damage by 20%.', bonus: { critDmg: 20 }, cost: 4 }, [
+            node({ name: 'Assassinate', desc: 'Finishing move for 100% more damage (30 stamina).', cost: 5, cast: 'assassinate' }, [
+              node({ name: 'Death Blossom', desc: 'Spin and strike nearby foes for 120% damage (35 stamina).', cost: 7, cast: 'deathBlossom' })
+            ])
+          ])
+        ])
+      ])
+    ]),
+    node({ name: 'Evasion Training', desc: 'Increase dodge chance by 5%.', bonus: { dodge: 5 }, cost: 1 }, [
+      node({ name: 'Shadowmeld', desc: 'Spend 25 stamina to become invisible for 4 seconds.', cost: 3, cast: 'vanish' }, [
+        node({ name: 'Silent Step', desc: 'Increase movement speed by 10% while stealthed.', bonus: { stealthSpeedPct: 10 }, cost: 4 }, [
+          node({ name: 'Smoke Bomb', desc: 'Create a smoke cloud that blinds enemies for 3 seconds (20 stamina).', cost: 5, cast: 'smokeBomb' }, [
+            node({ name: 'Master of Shadows', desc: 'Increase stealth duration by 2 seconds.', bonus: { stealthDur: 2 }, cost: 6 }, [
+              node({ name: 'Shadowmaster', desc: 'Attacks from stealth deal 50% more damage.', bonus: { stealthDmg: 50 }, cost: 8 })
+            ])
+          ])
+        ])
+      ])
     ])
   ])
 };
@@ -130,11 +148,13 @@ const magicTrees = {
 
 // Build skill trees for non-mage classes
 const warriorBranches = skillTreeGraph.warrior.children;
+const rogueBranches = skillTreeGraph.rogue.children;
 const skillTrees = {
   battle: { display: warriorBranches[0].name, class: 'warrior', abilities: flattenBranch(warriorBranches[0]), graph: warriorBranches[0] },
   endurance: { display: warriorBranches[1].name, class: 'warrior', abilities: flattenBranch(warriorBranches[1]), graph: warriorBranches[1] },
   warriorSkills: { display: warriorBranches[2].name, class: 'warrior', abilities: flattenBranch(warriorBranches[2]), graph: warriorBranches[2] },
-  rogue: { display: skillTreeGraph.rogue.name, class: 'rogue', abilities: flattenBranch(skillTreeGraph.rogue.children[0]), graph: skillTreeGraph.rogue.children[0] }
+  assassination: { display: 'Assassination', class: 'rogue', abilities: flattenBranch(rogueBranches[0]), graph: rogueBranches[0] },
+  shadow: { display: 'Shadow Arts', class: 'rogue', abilities: flattenBranch(rogueBranches[1]), graph: rogueBranches[1] }
 };
 
 // Initialize player progression structures

--- a/test/rogue-skills.test.js
+++ b/test/rogue-skills.test.js
@@ -28,3 +28,22 @@ test('Shadowmeld ability defined in rogue skill tree', () => {
   assert.equal(ability.cast, 'vanish');
   assert.equal(ability.cost, 3);
 });
+
+test('Backstab and Smoke Bomb abilities are present', () => {
+  const rogue = skillTreeGraph.rogue;
+  const backstab = findNode(rogue, 'Backstab');
+  assert.ok(backstab, 'Backstab ability present');
+  assert.equal(backstab.cost, 3);
+  const smoke = findNode(rogue, 'Smoke Bomb');
+  assert.ok(smoke, 'Smoke Bomb ability present');
+  assert.equal(smoke.cast, 'smokeBomb');
+  assert.equal(smoke.cost, 5);
+});
+
+test('rogue skill tree contains between 12 and 20 abilities', () => {
+  function count(node) {
+    return 1 + (node.children ? node.children.reduce((s, c) => s + count(c), 0) : 0);
+  }
+  const total = skillTreeGraph.rogue.children.reduce((sum, branch) => sum + count(branch), 0);
+  assert.ok(total >= 12 && total <= 20, `found ${total}`);
+});


### PR DESCRIPTION
## Summary
- flesh out rogue class with dual Assassination and Shadow Arts branches totaling 12 skills
- expose new rogue branches in skill tree registry and display class via skill tree graph
- add tests for new rogue abilities and ensure tree size constraints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12dafe8108322b996a69c7799ebf2