### PR TITLE
balance: improve mid-floor weapon scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Reduced wizard spawn chance on lower floors.
 - Increased potion drop rate to 40% (from 25%).
 - Mage enemies now fire 30% slower but hit 10% harder.
+- Increased level-based weapon damage scaling to keep pace with mid-floor monster health.
 - Mage enemies now use an animated skeleton sprite with purple energy.
 - Snake boss now uses an image sprite with a simple bobbing idle animation.
 - Enemy elemental resistances now scale with floor level.

--- a/game.js
+++ b/game.js
@@ -763,7 +763,7 @@ const ARMOR_AFFIX_POOL = [
 ];
 
 function levelMult(lvl, factor=1){
-  return 1 + (lvl - 1) * 0.1 * factor;
+  return 1 + (lvl - 1) * 0.15 * factor;
 }
 
 function affixMods(slot, rarityIdx, lvl=1){
@@ -1330,7 +1330,7 @@ canvas.addEventListener('mousedown', (e)=>{
 function currentAtk(){
   // why: single source-of-truth for attack numbers (incl. level & gear)
   let min=2,max=4,crit=5,ls=0,md=0;
-  const lvlBonus = Math.floor((player.lvl-1)*0.6); min+=lvlBonus; max+=lvlBonus;
+  const lvlBonus = Math.floor((player.lvl-1)*0.8); min+=lvlBonus; max+=lvlBonus;
   for(const slot of SLOTS){
     const m=inventory.equip[slot]?.mods||{};
     if(slot==='weapon'){ min+=m.dmgMin||0; max+=m.dmgMax||0; }


### PR DESCRIPTION
## Summary
- increase player level bonus to weapon damage
- boost weapon affix scaling so mid-floor weapons keep up with enemy health

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ed4f8aa483228d1d5164c38eca5d