### PR TITLE
Add classic-inspired mob types

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Recent updates rework the audio system with smoother sound effects and dynamic m
 
 The game now auto-saves your current floor and equipped gear to local storage when you leave the page. Use the pause menu to manually save or load this progress.
 
+### New Mob Types
+Two additional enemy types nod to classic pixel games:
+
+- **Invader** – a retro alien shooter that peppers the hero from afar.
+- **Chomper** – a fast, hungry foe that darts in for a bite.
+
 ## Play the Game
 Open `index.html` in your browser.  
 For full functionality, serve the directory with a local server:

--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -826,6 +826,43 @@ function genSprites(){
   }
   SPRITES.dragon_hatchling = makeDragonHatchling();
 
+  // Invader alien 24x24 (retro space shooter homage)
+  SPRITES.invader = makeSprite(24,(g,S)=>{
+    const pattern=[
+      "00011000",
+      "00111100",
+      "01111110",
+      "11011011",
+      "11111111",
+      "10111101",
+      "10100101",
+      "01000010"
+    ];
+    pattern.forEach((row, y)=>{
+      for(let x=0; x<row.length; x++){
+        if(row[x]==='1') px(g,4+x*2,4+y*2,2,2,'#7fef6f');
+      }
+    });
+    outline(g,S);
+  });
+
+  // Chomper 24x24 (maze-chasing arcade homage)
+  SPRITES.chomper = makeSprite(24,(g,S)=>{
+    const body='#ffd966';
+    const r=10, cx=12, cy=12;
+    for(let y=0; y<24; y++){
+      for(let x=0; x<24; x++){
+        const dx=x-cx, dy=y-cy;
+        if(dx*dx+dy*dy<=r*r){
+          if(dx>0 && Math.abs(dy) <= dx) continue; // mouth wedge
+          px(g,x,y,1,1,body);
+        }
+      }
+    }
+    px(g,14,10,2,2,'#000');
+    outline(g,S);
+  });
+
 
   // Portal animation 48x48 (replaces stairs)
   function makePortalSprite(){

--- a/game.js
+++ b/game.js
@@ -503,6 +503,8 @@ function chooseMonsterType(floor){
   if(floor>=3) pool.push({type:2, w:2}); // skeletons
   if(floor>=4) pool.push({type:6, w:1}); // ghosts
   if(floor>=5) pool.push({type:3, w:1}); // mages
+  if(floor>=6) pool.push({type:7, w:1}); // invaders
+  if(floor>=7) pool.push({type:8, w:1}); // chompers
   // weight tough enemies if player overpowered
   const power = player.lvl + (player.dmgMin + player.dmgMax)/4;
   if(power > floor*2){
@@ -528,6 +530,8 @@ function spawnMonster(type,x,y,elite=false){
     { hp:12, dmg:[3,6], atkCD:30, moveCD:[6,10] },    // dragon hatchling
     { hp:10, dmg:[2,5], atkCD:26, moveCD:[5,9] },     // goblin: agile melee
     { hp:8,  dmg:[1,4], atkCD:32, moveCD:[6,12] },    // ghost: drifting foe
+    { hp:9,  dmg:[2,5], atkCD:30, moveCD:[5,9] },     // invader: retro alien shooter
+    { hp:12, dmg:[3,6], atkCD:28, moveCD:[4,8] },     // chomper: fast arcade muncher
   ];
   let a = archetypes[type] || archetypes[0];
   let spriteKey;
@@ -558,6 +562,10 @@ function spawnMonster(type,x,y,elite=false){
     spriteKey = 'goblin';
   } else if(type===6){ // ghost
     spriteKey = 'ghost';
+  } else if(type===7){ // invader
+    spriteKey = 'invader';
+  } else if(type===8){ // chomper
+    spriteKey = 'chomper';
   }
   const diff = 1 + SCALE.HARDNESS_MULT * Math.max(0, floorNum-1);
   const m = {
@@ -1611,7 +1619,7 @@ function mageAI(m, dt, dx, dy, manhattan){
   }
 }
 
-const MONSTER_BEHAVIORS = {0:slimeAI,1:batAI,2:skeletonAI,3:mageAI,4:mageAI,5:goblinAI,6:ghostAI};
+const MONSTER_BEHAVIORS = {0:slimeAI,1:batAI,2:skeletonAI,3:mageAI,4:mageAI,5:goblinAI,6:ghostAI,7:skeletonAI,8:batAI};
 
 function monsterAI(m, dt){
   m.atkCD = Math.max(0, m.atkCD - 1);
@@ -1786,7 +1794,7 @@ function draw(dt){
     const mty = (m.ry!==undefined ? m.ry : m.y);
     const size = m.spriteSize || 24;
     const mx = mtx*TILE - camX + (TILE-size)/2; const my = mty*TILE - camY + (TILE-size)/2;
-    const key = m.spriteKey || (m.type===0?'slime' : m.type===1?'bat' : m.type===2?'skeleton' : m.type===5?'goblin' : m.type===6?'ghost' : 'mage');
+    const key = m.spriteKey || (m.type===0?'slime' : m.type===1?'bat' : m.type===2?'skeleton' : m.type===5?'goblin' : m.type===6?'ghost' : m.type===7?'invader' : m.type===8?'chomper' : 'mage');
     const spr = ASSETS.sprites[key];
     let frame = spr.cv;
     if(spr.frames && spr.frames.length>0){


### PR DESCRIPTION
## Summary
- Introduce Invader and Chomper mob types referencing retro pixel games
- Provide pixel sprites and spawn logic for new enemies
- Document new adversaries in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1eed8c9dc832283efccf862b43aee