### PR TITLE
feat: add optional mobile controls

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,5 +1,5 @@
 import { initAudio, playFootstep, playAttack, playHit, playCalmMusic, playCombatMusic, playBossMusic } from './modules/audio.js';
-import { keys, initInput } from './modules/input.js';
+import { keys, initInput, initMobileControls } from './modules/input.js';
 import { player, playerSpriteKey, magicTrees, skillTrees, skillTreeGraph, updatePlayerSprite } from './modules/player.js';
 import { inventory, SLOTS, BAG_SIZE, POTION_BAG_SIZE } from './modules/playerInventory.js';
 import { hpFill, mpFill, hpLbl, mpLbl, hudFloor, hudSeed, hudGold, hudDmg, hudScore, hudKills, xpFill, xpLbl, hudLvl, hudSpell, hudAbilityLabel, updateResourceUI, updateXPUI, updateScoreUI, toggleActionLog, showToast, showBossAlert, showRespawn } from './modules/ui.js';
@@ -2699,6 +2699,12 @@ function setupUIEvents(){
   if(playBtn) playBtn.addEventListener('click', ()=>{
     const startScreen=document.getElementById('start');
     if(startScreen) startScreen.style.display='none';
+    const mobileToggle=document.getElementById('mobileToggle');
+    if(mobileToggle && mobileToggle.checked){
+      const mc=document.getElementById('mobileControls');
+      if(mc) mc.style.display='block';
+      initMobileControls();
+    }
     startGame();
   });
 

--- a/index.html
+++ b/index.html
@@ -99,12 +99,28 @@
       </div>
 
     <p class="hint" style="margin-top:10px">All sprites (player, monsters, portal, shop) are generated at runtime.</p>
+
+    <label style="display:flex;align-items:center;gap:6px;margin-top:8px;pointer-events:auto">
+      <input type="checkbox" id="mobileToggle"> Mobile Controls (iOS)
+    </label>
+
       <div style="display:flex;gap:8px;margin-top:8px">
         <button id="playBtn" class="btn">Play</button>
         <button class="btn" onclick="alert('Thanks for playing!')">Quit</button>
         <a href="controls.html" class="btn" style="text-decoration:none;display:inline-block">Controls</a>
       </div>
   </div>
+</div>
+
+<!-- Mobile Controls Overlay -->
+<div id="mobileControls" style="display:none;position:fixed;inset:0;pointer-events:none">
+  <div id="dpad">
+    <button id="btnUp" class="mc-btn">▲</button>
+    <button id="btnLeft" class="mc-btn">◀</button>
+    <button id="btnDown" class="mc-btn">▼</button>
+    <button id="btnRight" class="mc-btn">▶</button>
+  </div>
+  <button id="btnAction" class="mc-btn">E</button>
 </div>
 
   <div id="respawn" class="stone" style="position:fixed;inset:0;display:none;place-items:center">

--- a/modules/input.js
+++ b/modules/input.js
@@ -11,4 +11,21 @@ function initInput(onAction) {
   });
 }
 
-export { keys, initInput };
+function initMobileControls() {
+  const bind = (id, key) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const on = e => { e.preventDefault(); keys[key] = true; };
+    const off = e => { e.preventDefault(); keys[key] = false; };
+    el.addEventListener('touchstart', on);
+    el.addEventListener('mousedown', on);
+    ['touchend','touchcancel','mouseup','mouseleave'].forEach(ev => el.addEventListener(ev, off));
+  };
+  bind('btnUp', 'w');
+  bind('btnDown', 's');
+  bind('btnLeft', 'a');
+  bind('btnRight', 'd');
+  bind('btnAction', 'e');
+}
+
+export { keys, initInput, initMobileControls };

--- a/style.css
+++ b/style.css
@@ -50,3 +50,15 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
   .gender-card:hover{background:#12141f}
   .gender-card input{accent-color:#7a4bd9}
   .gender-preview{width:32px;height:32px;border-radius:6px;background:#0f1119;display:grid;place-items:center}
+
+/* Mobile controls */
+#mobileControls{position:fixed;inset:0;pointer-events:none}
+#dpad{position:absolute;bottom:80px;left:30px;width:120px;height:120px}
+#dpad .mc-btn{position:absolute;width:40px;height:40px;border-radius:8px;background:#141622;border:1px solid #3a3e4d;color:#e6e6f0;opacity:.6;pointer-events:auto}
+#dpad .mc-btn:active{opacity:.9}
+#btnUp{left:40px;top:0}
+#btnDown{left:40px;top:80px}
+#btnLeft{left:0;top:40px}
+#btnRight{left:80px;top:40px}
+#btnAction{position:absolute;bottom:80px;right:30px;width:60px;height:60px;border-radius:30px;background:#141622;border:1px solid #3a3e4d;color:#e6e6f0;opacity:.6;pointer-events:auto}
+#btnAction:active{opacity:.9}


### PR DESCRIPTION
## Summary
- add optional iOS-style mobile controls selectable on start screen
- implement touch-driven input bindings for movement and action
- wire mobile controls into game startup and provide styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b207e9068c8322861c4878c8eb019c