### PR TITLE
feat: expand armor classifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - New weapon affixes: attack speed, knockback, and projectile pierce.
 - Weapons can roll up to four stacking damage-over-time attributes.
 - Armor can roll up to five defensive affixes.
+- Additional armor classifications (Cloth, Leather, Heavy Leather, Chain Mail, Plate, Heavy Plate) with defensive buffs.
 
 - Consumable potions appear in loot and shop inventories.
 - Legendary rarity added for gear and weapon drops.

--- a/game.js
+++ b/game.js
@@ -10,6 +10,7 @@ import { applyDamageToPlayer as coreApplyDamageToPlayer } from './modules/combat
 import { renderLayers } from './modules/rendering.js';
 import { MIN_ROOM_SIZE, connectRooms, pruneSmallAreas } from './modules/mapGen.js';
 import { createNoise2D } from './modules/noise.js';
+import { ARMOR_TYPES, ARMOR_TYPE_MODS } from './modules/armorTypes.js';
 
 // ===== Config / Globals =====
 let VIEW_W=window.innerWidth, VIEW_H=window.innerHeight;
@@ -1138,18 +1139,13 @@ function makeRandomGear(){
   const item = { color: RARITY[rarityIdx].c, type:'gear', slot, name, rarity: rarityIdx, lvl: floorNum, mods: affixMods(slot, rarityIdx, floorNum) };
   if(slot==='weapon'){ item.wclass = base.toLowerCase(); }
   else {
-    // Weighted armor types: 50% medium, 25% light, 25% heavy
-    const r = rng.next();
-    const t = r < 0.25 ? 'light' : r < 0.75 ? 'medium' : 'heavy';
-    const typeMods = {
-      light:{armor:3,speedPct:5},
-      medium:{armor:6,speedPct:0},
-      heavy:{armor:10,speedPct:-10}
-    };
+    // Armor types provide baseline stats and defensive buffs
+    const t = ARMOR_TYPES[rng.int(0, ARMOR_TYPES.length-1)];
     item.armorType = t;
-    const tm = typeMods[t];
-    item.mods.armor = (item.mods.armor||0) + tm.armor;
-    if(tm.speedPct) item.mods.speedPct = (item.mods.speedPct||0) + tm.speedPct;
+    const tm = ARMOR_TYPE_MODS[t];
+    for (const k in tm) {
+      item.mods[k] = (item.mods[k] || 0) + tm[k];
+    }
   }
   return item;
 }

--- a/modules/armorTypes.js
+++ b/modules/armorTypes.js
@@ -1,0 +1,10 @@
+export const ARMOR_TYPE_MODS = {
+  Cloth: { armor: 1, speedPct: 10, mpMax: 20 },
+  Leather: { armor: 4, speedPct: 5, spMax: 10 },
+  'Heavy Leather': { armor: 6, spMax: 20, hpMax: 10 },
+  'Chain Mail': { armor: 8, hpMax: 20, speedPct: -5 },
+  Plate: { armor: 12, hpMax: 30, speedPct: -10 },
+  'Heavy Plate': { armor: 16, hpMax: 40, speedPct: -15 }
+};
+
+export const ARMOR_TYPES = Object.keys(ARMOR_TYPE_MODS);

--- a/test/armor-types.test.js
+++ b/test/armor-types.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ARMOR_TYPES, ARMOR_TYPE_MODS } from '../modules/armorTypes.js';
+
+test('armor type list includes new classes', () => {
+  const expected = ['Cloth', 'Leather', 'Heavy Leather', 'Chain Mail', 'Plate', 'Heavy Plate'];
+  expected.forEach(t => assert(ARMOR_TYPES.includes(t)));
+});
+
+test('armor type stats scale by heaviness', () => {
+  assert.ok(ARMOR_TYPE_MODS['Cloth'].armor < ARMOR_TYPE_MODS['Heavy Plate'].armor);
+  assert.ok(ARMOR_TYPE_MODS['Cloth'].speedPct > 0);
+  assert.ok(ARMOR_TYPE_MODS['Heavy Plate'].speedPct < 0);
+});


### PR DESCRIPTION
## Summary
- add dedicated armor type map for cloth through heavy plate
- scale gear generation to apply armor-type bonuses
- document new armor classifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b229f7d4f083228df7027c0d2693a6