### PR TITLE
refactor: ensure unique skill tree names across classes

### DIFF
--- a/modules/player.js
+++ b/modules/player.js
@@ -151,22 +151,67 @@ function flattenBranch(branch) {
 const [healBranch, dmgBranch, dotBranch] = skillTreeGraph.mage.children;
 const summonerBranches = skillTreeGraph.summoner.children;
 const magicTrees = {
-  healing: { display: 'Healing', class: 'mage', abilities: flattenBranch(healBranch) },
-  damage: { display: 'Damage', class: 'mage', abilities: flattenBranch(dmgBranch) },
-  dot: { display: 'Damage over Time', class: 'mage', abilities: flattenBranch(dotBranch) },
-  summoning: { display: 'Summoning', class: 'summoner', abilities: flattenBranch(summonerBranches[0]) },
-  mastery: { display: 'Minion Mastery', class: 'summoner', abilities: flattenBranch(summonerBranches[1]) }
+  spellbinderHealing: {
+    display: 'Healing',
+    class: 'mage',
+    abilities: flattenBranch(healBranch)
+  },
+  spellbinderDamage: {
+    display: 'Damage',
+    class: 'mage',
+    abilities: flattenBranch(dmgBranch)
+  },
+  spellbinderDot: {
+    display: 'Damage over Time',
+    class: 'mage',
+    abilities: flattenBranch(dotBranch)
+  },
+  soulcallerSummoning: {
+    display: 'Summoning',
+    class: 'summoner',
+    abilities: flattenBranch(summonerBranches[0])
+  },
+  soulcallerMastery: {
+    display: 'Minion Mastery',
+    class: 'summoner',
+    abilities: flattenBranch(summonerBranches[1])
+  }
 };
 
 // Build skill trees for non-mage classes
 const warriorBranches = skillTreeGraph.warrior.children;
 const rogueBranches = skillTreeGraph.rogue.children;
 const skillTrees = {
-  battle: { display: warriorBranches[0].name, class: 'warrior', abilities: flattenBranch(warriorBranches[0]), graph: warriorBranches[0] },
-  endurance: { display: warriorBranches[1].name, class: 'warrior', abilities: flattenBranch(warriorBranches[1]), graph: warriorBranches[1] },
-  warriorSkills: { display: warriorBranches[2].name, class: 'warrior', abilities: flattenBranch(warriorBranches[2]), graph: warriorBranches[2] },
-  assassination: { display: 'Assassination', class: 'rogue', abilities: flattenBranch(rogueBranches[0]), graph: rogueBranches[0] },
-  shadow: { display: 'Shadow Arts', class: 'rogue', abilities: flattenBranch(rogueBranches[1]), graph: rogueBranches[1] }
+  berserkerBattle: {
+    display: warriorBranches[0].name,
+    class: 'warrior',
+    abilities: flattenBranch(warriorBranches[0]),
+    graph: warriorBranches[0]
+  },
+  berserkerEndurance: {
+    display: warriorBranches[1].name,
+    class: 'warrior',
+    abilities: flattenBranch(warriorBranches[1]),
+    graph: warriorBranches[1]
+  },
+  berserkerRage: {
+    display: warriorBranches[2].name,
+    class: 'warrior',
+    abilities: flattenBranch(warriorBranches[2]),
+    graph: warriorBranches[2]
+  },
+  nightbladeAssassination: {
+    display: 'Assassination',
+    class: 'rogue',
+    abilities: flattenBranch(rogueBranches[0]),
+    graph: rogueBranches[0]
+  },
+  nightbladeShadow: {
+    display: 'Shadow Arts',
+    class: 'rogue',
+    abilities: flattenBranch(rogueBranches[1]),
+    graph: rogueBranches[1]
+  }
 };
 
 // Initialize player progression structures

--- a/test/unique-skill-names.test.js
+++ b/test/unique-skill-names.test.js
@@ -1,0 +1,37 @@
+import assert from 'assert';
+import test from 'node:test';
+import { skillTreeGraph } from '../modules/player.js';
+
+function collectNames(node, set) {
+  set.add(node.name);
+  if (node.children) {
+    for (const child of node.children) {
+      collectNames(child, set);
+    }
+  }
+}
+
+test('skill names are unique across classes', () => {
+  const classes = Object.keys(skillTreeGraph);
+  const namesByClass = {};
+  for (const cls of classes) {
+    const set = new Set();
+    const root = skillTreeGraph[cls];
+    // include all names in this class's tree
+    collectNames(root, set);
+    namesByClass[cls] = set;
+  }
+  const entries = Object.entries(namesByClass);
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      const [a, setA] = entries[i];
+      const [b, setB] = entries[j];
+      const overlap = [...setA].filter(name => setB.has(name));
+      assert.strictEqual(
+        overlap.length,
+        0,
+        `Overlapping skills between ${a} and ${b}: ${overlap.join(', ')}`
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- prefix skill tree keys with class names to keep them distinct
- add tests verifying skill names don't overlap between classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2303be64883228efd078e57d01b68