### PR TITLE
feat: add audio volume controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An offline HTML5 dungeon crawler with inline sprites, now featuring Berserker, Spellbinder and Nightblade classes, a Berserker skill tree, consumable potions and legendary gear.
 
-Recent updates rework the audio system with smoother sound effects and dynamic music that cross‑fades between calm, combat and boss themes.
+Recent updates rework the audio system with smoother sound effects and dynamic music that cross‑fades between calm, combat and boss themes. Players can fine‑tune overall, music and SFX volume via new sliders stored in local storage.
 
 The game now auto-saves your current floor and equipped gear to local storage when you leave the page. Use the pause menu to manually save or load this progress.
 

--- a/game.js
+++ b/game.js
@@ -1,4 +1,4 @@
-import { initAudio, playFootstep, playAttack, playHit, playCalmMusic, playCombatMusic, playBossMusic } from './modules/audio.js';
+import { initAudio, playFootstep, playAttack, playHit, playCalmMusic, playCombatMusic, playBossMusic, setMasterVolume, setMusicVolume, setSfxVolume } from './modules/audio.js';
 import { keys, initInput, initMobileControls } from './modules/input.js';
 import { player, playerSpriteKey, magicTrees, skillTrees, skillTreeGraph, updatePlayerSprite } from './modules/player.js';
 import { inventory, SLOTS, BAG_SIZE, POTION_BAG_SIZE } from './modules/playerInventory.js';
@@ -2688,6 +2688,16 @@ function startGame(){
   const smoothToggle=document.getElementById('smoothToggle'); const speedRange=document.getElementById('speedRange');
   if(smoothToggle){ smoothToggle.checked = smoothEnabled; smoothToggle.addEventListener('change', e=>{ smoothEnabled = e.target.checked; if(!smoothEnabled){ player.rx=player.x; player.ry=player.y; } }); }
   if(speedRange){ baseStepDelay = player.stepDelay; speedRange.value = String(baseStepDelay); speedRange.addEventListener('input', e=>{ const v=parseInt(e.target.value,10); if(!isNaN(v)) baseStepDelay=v; }); }
+  const masterVol=document.getElementById('masterVol');
+  const musicVol=document.getElementById('musicVol');
+  const sfxVol=document.getElementById('sfxVol');
+  const masterVal=parseFloat(localStorage.getItem('volumeMaster')||'1');
+  const musicVal=parseFloat(localStorage.getItem('volumeMusic')||'1');
+  const sfxVal=parseFloat(localStorage.getItem('volumeSfx')||'1');
+  setMasterVolume(masterVal); setMusicVolume(musicVal); setSfxVolume(sfxVal);
+  if(masterVol){ masterVol.value=String(masterVal); masterVol.addEventListener('input', e=>{ const v=parseFloat(e.target.value); setMasterVolume(v); localStorage.setItem('volumeMaster', String(v)); }); }
+  if(musicVol){ musicVol.value=String(musicVal); musicVol.addEventListener('input', e=>{ const v=parseFloat(e.target.value); setMusicVolume(v); localStorage.setItem('volumeMusic', String(v)); }); }
+  if(sfxVol){ sfxVol.value=String(sfxVal); sfxVol.addEventListener('input', e=>{ const v=parseFloat(e.target.value); setSfxVolume(v); localStorage.setItem('volumeSfx', String(v)); }); }
   startLoop(update, draw);
 }
 

--- a/index.html
+++ b/index.html
@@ -40,6 +40,14 @@
       <label for="speedRange">Speed</label>
       <input type="range" id="speedRange" min="60" max="220" value="140" step="5" style="width:140px">
     </div>
+    <div class="hud-kv" style="display:flex;align-items:center;gap:4px; pointer-events:auto">
+      <label for="masterVol">Vol</label>
+      <input type="range" id="masterVol" min="0" max="1" step="0.01" value="1" style="width:80px">
+      <label for="musicVol">Mus</label>
+      <input type="range" id="musicVol" min="0" max="1" step="0.01" value="1" style="width:80px">
+      <label for="sfxVol">SFX</label>
+      <input type="range" id="sfxVol" min="0" max="1" step="0.01" value="1" style="width:80px">
+    </div>
   </div>
   <div></div>
   <div class="footer">Sprites generated at runtime — multi-file</div>

--- a/modules/audio.js
+++ b/modules/audio.js
@@ -113,5 +113,6 @@ function playBossMusic()   { if (currentMusic !== 'boss')   startMusic('boss'); 
 
 function setMusicVolume(v){ initAudio(); musicGain.gain.value = v; }
 function setSfxVolume(v){ initAudio(); sfxGain.gain.value = v; }
+function setMasterVolume(v){ initAudio(); masterGain.gain.value = v; }
 
-export { initAudio, playFootstep, playAttack, playHit, playCalmMusic, playCombatMusic, playBossMusic, setMusicVolume, setSfxVolume };
+export { initAudio, playFootstep, playAttack, playHit, playCalmMusic, playCombatMusic, playBossMusic, setMusicVolume, setSfxVolume, setMasterVolume };


### PR DESCRIPTION
## Summary
- add master, music, and sfx volume setters in audio module
- expose HUD sliders to adjust audio levels and persist to local storage
- document new configurable volume controls in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b24f2d02848322b89a9bc78e356444