### PR TITLE
Expand summoner summons and enable minion spawning

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,7 @@
 import { initAudio, playFootstep, playAttack, playHit, playCalmMusic, playCombatMusic, playBossMusic, setMasterVolume, setMusicVolume, setSfxVolume } from './modules/audio.js';
 import { keys, initInput, initMobileControls } from './modules/input.js';
 import { player, playerSpriteKey, magicTrees, skillTrees, skillTreeGraph, updatePlayerSprite } from './modules/player.js';
+import { minions, spawnMinion } from './modules/minions.js';
 import { inventory, SLOTS, BAG_SIZE, POTION_BAG_SIZE } from './modules/playerInventory.js';
 import { hpFill, mpFill, hpLbl, mpLbl, hudFloor, hudSeed, hudGold, hudDmg, hudScore, hudKills, xpFill, xpLbl, hudLvl, hudSpell, hudAbilityLabel, updateResourceUI, updateXPUI, updateScoreUI, toggleActionLog, showToast, showBossAlert, showRespawn } from './modules/ui.js';
 import { TILE, MAP_W, MAP_H, T_EMPTY, T_FLOOR, T_WALL, T_TRAP, T_LAVA, TRAP_CHANCE, LAVA_CHANCE, map, fog, vis, rooms, stairs, merchant, merchantStyle, torches, lavaTiles, spikeTraps, biomeMap, B_DESERT, B_FOREST, B_MOUNTAIN, walkable, canMoveFrom, resetMapState } from './modules/map.js';
@@ -2318,6 +2319,9 @@ function castSelectedSpell(){
     const amt=ab.value===null?player.hpMax:ab.value;
     const heal=Math.min(amt, player.hpMax-player.hp);
     player.hp+=heal; hpFill.style.width=`${(player.hp/player.hpMax)*100}%`; hpLbl.textContent=`HP ${player.hp}/${player.hpMax}`; addDamageText(player.x,player.y,'+'+heal,'#76d38b');
+    return;
+  } else if(ab.type==='summon') {
+    spawnMinion(ab.summon || 'skeleton', player.x, player.y);
     return;
   }
   const px = player.rx!==undefined?player.rx:player.x, py = player.ry!==undefined?player.ry:player.y;

--- a/modules/minions.js
+++ b/modules/minions.js
@@ -1,0 +1,7 @@
+export const minions = [];
+
+export function spawnMinion(type, x, y) {
+  const m = { type, x, y, hp: 10 };
+  minions.push(m);
+  return m;
+}

--- a/modules/player.js
+++ b/modules/player.js
@@ -124,8 +124,12 @@ const skillTreeGraph = {
   ]),
 
   summoner: node({ name: 'Soulcaller' }, [
-    node({ name: 'Summon Skeleton', type: 'summon', mp: 15, cost: 1 }, [
-      node({ name: 'Summon Golem', type: 'summon', mp: 30, cost: 2 })
+    node({ name: 'Summon Skeleton', type: 'summon', summon: 'skeleton', mp: 15, cost: 1 }, [
+      node({ name: 'Summon Golem', type: 'summon', summon: 'golem', mp: 30, cost: 2 }, [
+        node({ name: 'Summon Demon', type: 'summon', summon: 'demon', mp: 45, cost: 3 }, [
+          node({ name: 'Summon Dragon', type: 'summon', summon: 'dragon', mp: 60, cost: 4 })
+        ])
+      ])
     ]),
     node({ name: 'Empower Minions', desc: 'Increase minion damage by 10%.', bonus: { minionDmg: 10 }, cost: 1 }, [
       node({ name: 'Horde Mastery', desc: 'Increase max minions by 1.', bonus: { maxMinions: 1 }, cost: 2 })

--- a/test/minion-summon.test.js
+++ b/test/minion-summon.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { minions, spawnMinion } from '../modules/minions.js';
+
+test('spawnMinion adds to minion list', () => {
+  minions.length = 0;
+  const m = spawnMinion('skeleton', 1, 2);
+  assert.equal(minions.length, 1);
+  assert.equal(m, minions[0]);
+  assert.equal(m.type, 'skeleton');
+  assert.equal(m.x, 1);
+  assert.equal(m.y, 2);
+});

--- a/test/summoner-skills.test.js
+++ b/test/summoner-skills.test.js
@@ -28,6 +28,14 @@ test('Summon Golem ability defined in summoner skill tree', () => {
   assert.equal(ability.cost, 2);
 });
 
+test('Summon Demon ability defined in summoner skill tree', () => {
+  const summoner = skillTreeGraph.summoner;
+  const ability = findNode(summoner, 'Summon Demon');
+  assert.ok(ability, 'Summon Demon ability present');
+  assert.equal(ability.type, 'summon');
+  assert.equal(ability.cost, 3);
+});
+
 test('summoner skill tree contains between 4 and 8 abilities', () => {
   function count(node) {
     return 1 + (node.children ? node.children.reduce((s, c) => s + count(c), 0) : 0);


### PR DESCRIPTION
## Summary
- extend Soulcaller skill tree with demon and dragon summon abilities
- add reusable minion spawning helper and hook into spell casting
- cover new summon and minion helper with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3a286c31883229ef6ad8aa2e3e64e