### PR TITLE
Implement basic minion allies for summoner

### DIFF
--- a/modules/minions.js
+++ b/modules/minions.js
@@ -1,7 +1,35 @@
 export const minions = [];
 
+const MINION_STATS = {
+  skeleton: { hp: 15, dmg: [2, 4], sprite: 'skeleton', stepDelay: 300, atkDelay: 600 },
+  golem: { hp: 25, dmg: [4, 6], sprite: 'goblin', stepDelay: 400, atkDelay: 800 },
+  demon: { hp: 20, dmg: [5, 8], sprite: 'mage', stepDelay: 300, atkDelay: 700 },
+  dragon: { hp: 30, dmg: [6, 10], sprite: 'dragon_hatchling', stepDelay: 300, atkDelay: 650 }
+};
+
 export function spawnMinion(type, x, y) {
-  const m = { type, x, y, hp: 10 };
+  const cfg = MINION_STATS[type] || MINION_STATS.skeleton;
+  const m = {
+    type,
+    x,
+    y,
+    rx: x,
+    ry: y,
+    hpMax: cfg.hp,
+    hp: cfg.hp,
+    dmgMin: cfg.dmg[0],
+    dmgMax: cfg.dmg[1],
+    spriteKey: cfg.sprite,
+    stepDelay: cfg.stepDelay,
+    atkDelay: cfg.atkDelay,
+    atkCD: 0,
+    stepCD: 0,
+    moving: false,
+    moveT: 1,
+    moveDur: cfg.stepDelay
+  };
   minions.push(m);
   return m;
 }
+
+export { MINION_STATS };


### PR DESCRIPTION
## Summary
- flesh out minion stats and spawning details
- update game loop to move and render friendly minions that attack monsters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c29f30c083228132f9bf4585c85b