### PR TITLE
feat: spawn random treasure chests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 
 ## [Unreleased]
 ### Added
+- Random treasure chests (2–5 per floor) spawn around the map with loot.
 - Optional cellular‑automata cave floors with secret rooms and environmental hazards like spike traps and lava.
 - Animated tiles for lava pools and spike traps.
 - Project license clarifying sole ownership.

--- a/game.js
+++ b/game.js
@@ -486,6 +486,7 @@ function generate(){
   buildLayers();
   recomputeFOV();
   seedRoomLoot();
+  spawnChests();
   genShopStock();
   redrawInventory();
   renderShop();
@@ -831,6 +832,22 @@ function seedRoomLoot(){
   }
 }
 
+function spawnChests(){
+  const chestCount = rng.int(2,5);
+  let placed = 0, attempts = 0;
+  while(placed < chestCount && attempts < 1000){
+    const x = rng.int(1, MAP_W-1), y = rng.int(1, MAP_H-1);
+    if(map[y*MAP_W+x] !== T_FLOOR){ attempts++; continue; }
+    if((x===player.x && y===player.y) || (x===merchant.x && y===merchant.y) || (x===stairs.x && y===stairs.y)){
+      attempts++; continue;
+    }
+    const key = `${x},${y}`;
+    if(lootMap.has(key)){ attempts++; continue; }
+    lootMap.set(key,{type:'chest', color:'#b8860b'});
+    placed++;
+  }
+}
+
 function pickupHere(){
   const key = `${player.x},${player.y}`;
   const it = lootMap.get(key);
@@ -845,6 +862,13 @@ function pickupHere(){
     if(pidx === -1){ showToast('Potion bag full'); return; }
     inventory.potionBag[pidx] = it; lootMap.delete(key); showToast(`Picked up ${it.name}`); player.itemsCollected++;
     redrawInventory();
+    return;
+  }
+  if(it.type === 'chest'){
+    lootMap.delete(key);
+    const drops = rng.int(1,3);
+    for(let i=0;i<drops;i++) dropLoot(player.x, player.y);
+    showToast('Opened a chest!');
     return;
   }
   const idx = inventory.bag.findIndex(b=>!b);
@@ -1655,6 +1679,15 @@ function drawLootIcon(it, x, y){
     const frames = spr.frames;
     const idx = frames.length ? Math.floor(performance.now()/100)%frames.length : 0;
     ctx.drawImage(frames[idx]||spr.cv, x+1, y+1);
+  }else if(it.type==='chest'){
+    ctx.fillStyle = '#8b4513';
+    ctx.fillRect(x+1, y+5, 12, 8);
+    ctx.fillStyle = '#cd853f';
+    ctx.fillRect(x+1, y+3, 12, 4);
+    ctx.strokeRect(x+1, y+3, 12, 10);
+    ctx.fillStyle = '#d2b48c';
+    ctx.fillRect(x+6, y+8, 2, 2);
+    ctx.strokeRect(x+6, y+8, 2, 2);
   }else{
     switch(it.slot){
       case 'weapon':


### PR DESCRIPTION
## Summary
- Generate 2-5 treasure chests per floor that drop loot when opened
- Draw chest icons and handle opening logic
- Document chest feature in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c2b55684832285240b1231b8fb7a