### PR TITLE
Add rare mimic chest mini boss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 ## [Unreleased]
 ### Added
 - Random treasure chests (2–5 per floor) spawn around the map with loot.
+- Chests now have a rare chance to be mimics that ambush the player.
 - Optional cellular‑automata cave floors with secret rooms and environmental hazards like spike traps and lava.
 - Animated tiles for lava pools and spike traps.
 - Project license clarifying sole ownership.

--- a/game.js
+++ b/game.js
@@ -843,7 +843,8 @@ function spawnChests(){
     }
     const key = `${x},${y}`;
     if(lootMap.has(key)){ attempts++; continue; }
-    lootMap.set(key,{type:'chest', color:'#b8860b'});
+    const isMimic = rng.int(1,600) === 1;
+    lootMap.set(key,{type:'chest', color:'#b8860b', mimic:isMimic});
     placed++;
   }
 }
@@ -866,9 +867,20 @@ function pickupHere(){
   }
   if(it.type === 'chest'){
     lootMap.delete(key);
-    const drops = rng.int(1,3);
-    for(let i=0;i<drops;i++) dropLoot(player.x, player.y);
-    showToast('Opened a chest!');
+    if(it.mimic){
+      const m = spawnMonster(8, player.x, player.y);
+      m.hpMax *= 2; m.hp = m.hpMax;
+      m.miniBoss = true;
+      const dmg = rng.int(m.dmgMin, m.dmgMax);
+      applyDamageToPlayer(dmg);
+      m.atkCD = rng.int(20, 35);
+      monsters.push(m);
+      showToast("It's a mimic!");
+    }else{
+      const drops = rng.int(1,3);
+      for(let i=0;i<drops;i++) dropLoot(player.x, player.y);
+      showToast('Opened a chest!');
+    }
     return;
   }
   const idx = inventory.bag.findIndex(b=>!b);


### PR DESCRIPTION
## Summary
- Give chests a 1-in-600 chance to be mimics
- Mimic chests reveal as mini bosses, attack on discovery, and have doubled health
- Document mimic chest addition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4c4482dc4832288cbc0bb6b94c502