### PR TITLE
Persist inventory and abilities across saves

### DIFF
--- a/modules/saveLoad.js
+++ b/modules/saveLoad.js
@@ -1,0 +1,57 @@
+import { player } from './player.js';
+import { inventory, BAG_SIZE, POTION_BAG_SIZE } from './playerInventory.js';
+
+const deepClone = obj => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(obj);
+  }
+  return JSON.parse(JSON.stringify(obj));
+};
+
+function getSaveData() {
+  return deepClone({
+    player: {
+      class: player.class,
+      lvl: player.lvl,
+      gold: player.gold,
+      skillPoints: player.skillPoints,
+      magicPoints: player.magicPoints,
+      skills: player.skills,
+      magic: player.magic,
+      boundSkill: player.boundSkill,
+      boundSpell: player.boundSpell
+    },
+    inventory: {
+      equip: inventory.equip,
+      bag: inventory.bag,
+      potionBag: inventory.potionBag
+    }
+  });
+}
+
+function applySaveData(data = {}) {
+  const p = data.player || {};
+  player.class = p.class ?? player.class;
+  player.lvl = p.lvl ?? player.lvl;
+  player.gold = p.gold ?? 0;
+  player.skillPoints = p.skillPoints ?? 0;
+  player.magicPoints = p.magicPoints ?? 0;
+  player.skills = deepClone(p.skills || player.skills);
+  player.magic = deepClone(p.magic || player.magic);
+  player.boundSkill = p.boundSkill ?? null;
+  player.boundSpell = p.boundSpell ?? null;
+
+  const inv = data.inventory || {};
+  inventory.equip = deepClone(
+    inv.equip || { helmet: null, chest: null, legs: null, hands: null, feet: null, weapon: null }
+  );
+  inventory.bag = deepClone(inv.bag || new Array(BAG_SIZE).fill(null));
+  inventory.potionBag = deepClone(inv.potionBag || new Array(POTION_BAG_SIZE).fill(null));
+
+  // keep player references in sync
+  player.equip = inventory.equip;
+  player.bag = inventory.bag;
+  player.potionBag = inventory.potionBag;
+}
+
+export { getSaveData, applySaveData };

--- a/test/save-load.test.js
+++ b/test/save-load.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { player } from '../modules/player.js';
+import { inventory } from '../modules/playerInventory.js';
+import { getSaveData, applySaveData } from '../modules/saveLoad.js';
+
+function setupState(){
+  // ensure known clean state? after import player & inventory already set.
+  // We'll reset arrays/equip to ensure test isolation
+  inventory.equip = { helmet:null, chest:null, legs:null, hands:null, feet:null, weapon:null };
+  inventory.bag = new Array(inventory.bag.length).fill(null);
+  inventory.potionBag = new Array(inventory.potionBag.length).fill(null);
+  player.skillPoints = 0;
+  player.magicPoints = 0;
+  for(const tree in player.skills){
+    player.skills[tree] = player.skills[tree].map(()=>false);
+  }
+  for(const tree in player.magic){
+    player.magic[tree] = player.magic[tree].map(()=>false);
+  }
+  player.boundSkill = null;
+  player.boundSpell = null;
+}
+
+test('inventory and abilities persist through save data', () => {
+  setupState();
+  // give player some state
+  inventory.equip.weapon = { name: 'Sword of Tests' };
+  inventory.bag[0] = { name: 'Health Potion' };
+  inventory.potionBag[0] = { name: 'Mana Potion' };
+  player.skillPoints = 2;
+  player.magicPoints = 3;
+  player.skills.berserkerBattle[0] = true;
+  player.magic.spellbinderHealing[0] = true;
+  player.boundSkill = { tree: 'berserkerBattle', idx: 0 };
+  player.boundSpell = { tree: 'spellbinderHealing', idx: 0 };
+
+  const data = getSaveData();
+
+  // mutate state to ensure we actually restore from save
+  setupState();
+
+  applySaveData(data);
+
+  assert.equal(inventory.equip.weapon.name, 'Sword of Tests');
+  assert.equal(inventory.bag[0].name, 'Health Potion');
+  assert.equal(inventory.potionBag[0].name, 'Mana Potion');
+  assert.equal(player.skillPoints, 2);
+  assert.equal(player.magicPoints, 3);
+  assert.ok(player.skills.berserkerBattle[0]);
+  assert.ok(player.magic.spellbinderHealing[0]);
+  assert.deepEqual(player.boundSkill, { tree: 'berserkerBattle', idx: 0 });
+  assert.deepEqual(player.boundSpell, { tree: 'spellbinderHealing', idx: 0 });
+
+  // clean up to avoid affecting other tests
+  setupState();
+});


### PR DESCRIPTION
## Summary
- add saveLoad module to serialize player inventory, skill points and unlocked abilities
- update saveGame/loadGame to preserve inventory, skill/magic points, and bound spells/skills
- cover persistence logic with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4cd2b3fdc832288926fa528711dac