### PR TITLE
feat: boost late-floor gear scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 - Health and mana potions now use custom SVG sprites with rarity glow and a simple rotation animation.
 - Weapon damage and armor/resistance values now scale with item level and rarity. Player base resistances increase slightly each level.
 - Gear slot drops now balance weapons and armor with dynamic weighting and floor-based scaling.
+- Increased weapon and armor stat scaling beyond floor 25 to keep pace with high-level monsters.
 
 ### Removed
 - Blue slime enemy variant.

--- a/game.js
+++ b/game.js
@@ -776,7 +776,14 @@ const ARMOR_AFFIX_POOL = [
 ];
 
 function levelMult(lvl, factor=1){
-  return 1 + (lvl - 1) * 0.15 * factor;
+  const early = 0.15 * factor;
+  const late = 0.30 * factor;
+  const breakpoint = 25;
+  if(lvl > breakpoint){
+    const base = 1 + (breakpoint - 1) * early;
+    return base + (lvl - breakpoint) * late;
+  }
+  return 1 + (lvl - 1) * early;
 }
 
 function affixMods(slot, rarityIdx, lvl=1){


### PR DESCRIPTION
## Summary
- Increase weapon and armor stat multipliers for floors beyond 25
- Document gear scaling boost in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4ec1778108322a95c4cfcb17cd3b8