### PR TITLE
Guarantee rooms have multiple exits

### DIFF
--- a/modules/mapGen.js
+++ b/modules/mapGen.js
@@ -21,6 +21,11 @@ function connectRooms(rng, extra=1){
     y: r.y + ((r.h/2)|0)
   }));
 
+  const edgeKey = (a,b) => a<b ? `${a},${b}` : `${b},${a}`;
+  const degrees = Array(centers.length).fill(0);
+  const edges = new Set();
+
+  // minimum spanning tree to ensure connectivity
   const connected = new Set([0]);
   while(connected.size < centers.length){
     let bestA=-1,bestB=-1,bestDist=Infinity;
@@ -35,6 +40,8 @@ function connectRooms(rng, extra=1){
     const a=centers[bestA], b=centers[bestB];
     carveHallway(rng, a.x,a.y,b.x,b.y);
     connected.add(bestB);
+    degrees[bestA]++; degrees[bestB]++;
+    edges.add(edgeKey(bestA,bestB));
   }
 
   // add some extra random connections for loops
@@ -43,6 +50,19 @@ function connectRooms(rng, extra=1){
     let b=rng.int(0, centers.length-1);
     if(a===b) b=(b+1)%centers.length;
     carveHallway(rng, centers[a].x, centers[a].y, centers[b].x, centers[b].y);
+    degrees[a]++; degrees[b]++;
+    edges.add(edgeKey(a,b));
+  }
+
+  // ensure every room has at least two exits
+  for(let i=0;i<centers.length;i++){
+    if(degrees[i] >= 2) continue;
+    for(let j=0;j<centers.length && degrees[i] < 2;j++){
+      if(i===j || edges.has(edgeKey(i,j))) continue;
+      carveHallway(rng, centers[i].x, centers[i].y, centers[j].x, centers[j].y);
+      degrees[i]++; degrees[j]++;
+      edges.add(edgeKey(i,j));
+    }
   }
 }
 

--- a/test/roomExits.test.js
+++ b/test/roomExits.test.js
@@ -1,0 +1,44 @@
+import { strict as assert } from 'assert';
+import { map, rooms, MAP_W, MAP_H, T_FLOOR, resetMapState } from '../modules/map.js';
+import { connectRooms } from '../modules/mapGen.js';
+
+class RNG {
+  constructor(seed=1){ this.s=seed; }
+  next(){ this.s=(this.s*1664525+1013904223)|0; return (this.s>>>0)/4294967296; }
+  int(a,b){ return Math.floor(a + (b-a+1)*this.next()); }
+}
+
+function addRoom(x,y,w,h){
+  rooms.push({x,y,w,h});
+  for(let yy=y; yy<y+h; yy++) for(let xx=x; xx<x+w; xx++) map[yy*MAP_W+xx]=T_FLOOR;
+}
+
+function countExits(r){
+  const cx=r.x+((r.w/2)|0);
+  const cy=r.y+((r.h/2)|0);
+  let exits=0;
+  for(const [dx,dy] of [[1,0],[-1,0],[0,1],[0,-1]]){
+    let x=cx, y=cy;
+    while(x>=r.x && x<r.x+r.w && y>=r.y && y<r.y+r.h){
+      x+=dx; y+=dy;
+    }
+    if(x<0||y<0||x>=MAP_W||y>=MAP_H) continue;
+    if(map[y*MAP_W+x]===T_FLOOR) exits++;
+  }
+  return exits;
+}
+
+resetMapState();
+addRoom(2,2,4,4);
+addRoom(12,2,4,4);
+addRoom(2,12,4,4);
+addRoom(12,12,4,4);
+
+const rng=new RNG(123);
+connectRooms(rng, 0);
+
+for(const r of rooms){
+  assert.ok(countExits(r) >= 2, 'room should have at least two exits');
+}
+
+resetMapState();


### PR DESCRIPTION
## Summary
- Track room connections with degree counts when linking dungeon rooms
- Ensure rooms with fewer than two exits get extra hallways
- Add regression test verifying each room has at least two exits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b520d1d26c8322b6395ecde3702094