### PR TITLE
Fix tests to handle expanded inventory slots

### DIFF
--- a/test/save-load.test.js
+++ b/test/save-load.test.js
@@ -2,13 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { player } from '../modules/player.js';
-import { inventory } from '../modules/playerInventory.js';
+import { inventory, SLOTS } from '../modules/playerInventory.js';
 import { getSaveData, applySaveData } from '../modules/saveLoad.js';
 
 function setupState(){
   // ensure known clean state? after import player & inventory already set.
   // We'll reset arrays/equip to ensure test isolation
-  inventory.equip = { helmet:null, chest:null, legs:null, hands:null, feet:null, weapon:null };
+  inventory.equip = Object.fromEntries(SLOTS.map(s => [s, null]));
   inventory.bag = new Array(inventory.bag.length).fill(null);
   inventory.potionBag = new Array(inventory.potionBag.length).fill(null);
   player.skillPoints = 0;
@@ -27,6 +27,7 @@ test('inventory and abilities persist through save data', () => {
   setupState();
   // give player some state
   inventory.equip.weapon = { name: 'Sword of Tests' };
+  inventory.equip.necklace = { name: 'Amulet of Tests' };
   inventory.bag[0] = { name: 'Health Potion' };
   inventory.potionBag[0] = { name: 'Mana Potion' };
   player.skillPoints = 2;
@@ -46,6 +47,7 @@ test('inventory and abilities persist through save data', () => {
   assert.equal(inventory.equip.weapon.name, 'Sword of Tests');
   assert.equal(inventory.bag[0].name, 'Health Potion');
   assert.equal(inventory.potionBag[0].name, 'Mana Potion');
+  assert.equal(inventory.equip.necklace.name, 'Amulet of Tests');
   assert.equal(player.skillPoints, 2);
   assert.equal(player.magicPoints, 3);
   assert.ok(player.skills.berserkerBattle[0]);


### PR DESCRIPTION
## Summary
- reset test inventory using slot list constant
- verify necklace slot is saved and loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ae95a9e483228da11f4aea622ac0