### PR TITLE
Expand inventory and add hover comparison

### DIFF
--- a/game.js
+++ b/game.js
@@ -1024,7 +1024,9 @@ function redrawInventory(){
   html += '<div class="inventory-footer"><div class="footer-item">HP '+player.hp+'/'+currentStats.hpMax+'</div><div class="footer-item">Gold '+player.gold+'</div></div>';
   html += '</div>';
   html += '</div>';
+  html += '<div id="invCompare" class="panel"></div>';
   panel.innerHTML = html;
+  const cmp=document.getElementById('invCompare'); if(cmp) cmp.style.display='none';
 
   const portrait = document.getElementById('invChar');
   if(portrait && SPRITES[playerSpriteKey]){
@@ -1064,27 +1066,39 @@ function showItemDetailsFromRow(row){
   const det = document.getElementById('invDetails');
   det.dataset.sel=''; det.dataset.kind='';
   const t=row.dataset.type;
-  if(!t){ setDetailsText(INV_DETAILS_DEFAULT); disableInvActions(); return; }
+  if(!t){ setDetailsText(INV_DETAILS_DEFAULT); disableInvActions(); showCompare(null); return; }
   if(t==='bag'){
-    const i=parseInt(row.dataset.idx,10); const it=inventory.bag[i]; if(!it){ setDetailsText('(empty slot)'); disableInvActions(); return; }
+    const i=parseInt(row.dataset.idx,10); const it=inventory.bag[i]; if(!it){ setDetailsText('(empty slot)'); disableInvActions(); showCompare(null); return; }
     det.dataset.sel=String(i); det.dataset.kind='bag';
     setDetailsText(renderDetails(it, 'bag'));
     document.getElementById('btnSell').disabled=false; document.getElementById('btnDrop').disabled=false;
+    showCompare(it);
   }else if(t==='pbag'){
-    const i=parseInt(row.dataset.idx,10); const it=inventory.potionBag[i]; if(!it){ setDetailsText('(empty slot)'); disableInvActions(); return; }
+    const i=parseInt(row.dataset.idx,10); const it=inventory.potionBag[i]; if(!it){ setDetailsText('(empty slot)'); disableInvActions(); showCompare(null); return; }
     det.dataset.sel=String(i); det.dataset.kind='pbag';
     setDetailsText(renderDetails(it, 'bag'));
     document.getElementById('btnSell').disabled=false; document.getElementById('btnDrop').disabled=false;
+    showCompare(null);
   }else if(t==='eq'){
-    const slot=row.dataset.slot; const it=inventory.equip[slot]; if(!it){ setDetailsText(`No ${slot} equipped.`); disableInvActions(); return; }
+    const slot=row.dataset.slot; const it=inventory.equip[slot]; if(!it){ setDetailsText(`No ${slot} equipped.`); disableInvActions(); showCompare(null); return; }
     det.dataset.sel=slot; det.dataset.kind='eq';
     setDetailsText(renderDetails(it, 'eq'));
     document.getElementById('btnSell').disabled=false; document.getElementById('btnDrop').disabled=true; // avoid dropping equipped directly
+    showCompare(null);
   }
 }
 
 function disableInvActions(){ document.getElementById('btnSell').disabled=true; document.getElementById('btnDrop').disabled=true; }
 function setDetailsText(html){ const det=document.getElementById('invDetails'); det.innerHTML=html; }
+
+function showCompare(it){
+  const cmp=document.getElementById('invCompare'); if(!cmp) return;
+  if(!it || !it.slot){ cmp.style.display='none'; cmp.innerHTML=''; return; }
+  const eq=inventory.equip[it.slot];
+  if(!eq){ cmp.style.display='none'; cmp.innerHTML=''; return; }
+  cmp.innerHTML=`<div class="section-title">Equipped</div>${renderDetails(eq,'eq')}<div class="hr"></div><div class="section-title">Hovered</div>${renderDetails(it,'bag')}`;
+  cmp.style.display='block';
+}
 
 function shortMods(it){
   if(it.type==='potion'){

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
   .stone{background-image:linear-gradient(180deg,rgba(255,255,255,.03),rgba(0,0,0,.08));}
   .footer{padding:6px 12px;border-top:1px solid #2a2d39;background:linear-gradient(#0f1016,#0b0c11);opacity:.85}
   #bossAlert{position:fixed;top:20px;left:50%;transform:translateX(-50%);padding:8px 14px;background:#141622;border:1px solid #3a3e4d;border-radius:8px;pointer-events:none;opacity:.95;z-index:1000}
-  #inventory{display:none;position:fixed;right:8px;top:72px;padding:12px;pointer-events:auto;font-size:13px;width:900px;max-width:95vw}
+   #inventory{display:none;position:fixed;right:8px;top:72px;padding:12px;pointer-events:auto;font-size:13px;width:1100px;max-width:95vw}
   #shop{display:none;position:fixed;left:8px;top:64px;min-width:320px;width:620px;max-width:90vw;max-height:70vh;overflow:auto;padding:10px 12px;pointer-events:auto;font-size:13px}
   #magic{display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);padding:8px 12px;pointer-events:auto;font-size:13px;width:340px;max-width:90vw;max-height:70vh;overflow:auto}
   #skills{display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);padding:8px 12px;pointer-events:auto;font-size:13px;width:340px;max-width:90vw;max-height:70vh;overflow:auto}
@@ -32,17 +32,18 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
 #inventory .inventory-layout{display:flex;gap:16px}
 #inventory .inv-left{width:180px;display:flex;flex-direction:column;align-items:center}
 #inventory .char-portrait{width:96px;height:96px;border:1px solid #2a2d39;border-radius:6px;background:#0f1119;margin-bottom:8px;display:flex;align-items:center;justify-content:center}
-#inventory .equip-grid{display:grid;grid-template-columns:repeat(2,48px);gap:12px}
+  #inventory .equip-grid{display:grid;grid-template-columns:repeat(2,96px);gap:12px}
 #inventory .inv-right{flex:1;display:flex;flex-direction:column}
-#inventory .inv-slot{width:48px;height:48px;border:1px solid #2a2d39;border-radius:6px;background:#10131c;display:flex;align-items:center;justify-content:center;cursor:pointer;box-sizing:border-box;padding:0}
+  #inventory .inv-slot{width:96px;height:60px;border:1px solid #2a2d39;border-radius:6px;background:#10131c;display:flex;align-items:center;justify-content:center;cursor:pointer;box-sizing:border-box;padding:0}
 #inventory .inv-slot.empty{opacity:.4}
-#inventory .item-name{font-size:10px;text-align:center;display:block;width:100%;padding:2px;box-sizing:border-box;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-#inventory .potion-grid{display:grid;grid-template-columns:repeat(3,48px);gap:12px;margin-bottom:12px}
-#inventory .bag-grid{display:grid;grid-template-columns:repeat(8,48px);gap:12px}
-#inventory #invDetails{margin-top:8px;min-height:40px}
+  #inventory .item-name{font-size:12px;text-align:center;display:block;width:100%;padding:2px;box-sizing:border-box;white-space:normal;overflow:visible;text-overflow:clip}
+  #inventory .potion-grid{display:grid;grid-template-columns:repeat(3,96px);gap:12px;margin-bottom:12px}
+  #inventory .bag-grid{display:grid;grid-template-columns:repeat(8,96px);gap:12px}
+  #inventory #invDetails{margin-top:8px;min-height:40px}
 #inventory .inventory-footer{display:flex;gap:12px;margin-top:8px;font-size:12px}
 #inventory .inventory-footer .footer-item{display:flex;align-items:center;gap:4px}
-#inventory .list-row:hover{background:#1a1d28}
+  #inventory .list-row:hover{background:#1a1d28}
+  #inventory #invCompare{position:absolute;bottom:12px;right:12px;display:none;padding:8px;min-width:260px;max-width:40%;max-height:40vh;overflow:auto}
 .skill-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:8px}
 .skill-card{display:flex;flex-direction:column;gap:4px;padding:6px;border-radius:6px}
 .skill-card:hover{background:#1a1d28}


### PR DESCRIPTION
## Summary
- Enlarge inventory slots and panel width to show full item names
- Add bottom-right comparison window that displays hovered item against equipped gear

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5c590c36c8322968e773fd3ab7e09