### PR TITLE
Add weapon icons and refine inventory UI

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -329,6 +329,17 @@ function genSprites(){
     return sprite;
   }
 
+  function makeIcon(svg, size = 14){
+    const img = new Image();
+    const c = document.createElement('canvas');
+    c.width = c.height = size;
+    const g = c.getContext('2d');
+    g.imageSmoothingEnabled = false;
+    img.onload = () => { g.clearRect(0,0,size,size); g.drawImage(img,0,0,size,size); };
+    img.src = URL.createObjectURL(new Blob([svg], {type: 'image/svg+xml'}));
+    return { cv: c };
+  }
+
   const hpPotionSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
   <!-- Palette -->
   <!-- O = outline #6b0018, B = body #d61a3c, H = highlight #ff9aaa, D = deep red #a10f28 -->
@@ -556,6 +567,69 @@ function genSprites(){
   </svg>`;
   SPRITES.ring_loot = makeSpinAnim(ringLootSVG);
   SPRITES.necklace_loot = makeSpinAnim(necklaceLootSVG);
+
+  const axeSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+    <rect x="5" y="1" width="2" height="9" fill="#8b5a2b"/>
+    <rect x="3" y="1" width="3" height="4" fill="#dcdcdc"/>
+    <rect x="6" y="1" width="3" height="4" fill="#a0a0a0"/>
+  </svg>`;
+  const maceSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+    <rect x="5" y="2" width="2" height="6" fill="#8b5a2b"/>
+    <rect x="4" y="0" width="4" height="4" fill="#dcdcdc"/>
+  </svg>`;
+  const daggerSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+    <rect x="5" y="1" width="2" height="4" fill="#dcdcdc"/>
+    <rect x="4" y="5" width="4" height="1" fill="#b8860b"/>
+    <rect x="5" y="6" width="2" height="3" fill="#8b4513"/>
+  </svg>`;
+  const wandSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+    <rect x="5" y="2" width="2" height="6" fill="#8b5a2b"/>
+    <rect x="5" y="0" width="2" height="2" fill="#b84aff"/>
+  </svg>`;
+  const staffSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+    <rect x="5" y="1" width="2" height="8" fill="#8b5a2b"/>
+    <rect x="4" y="0" width="4" height="2" fill="#c0c0c0"/>
+  </svg>`;
+  const spearSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+    <path d="M6 0 L9 3 H3 L6 0" fill="#dcdcdc"/>
+    <rect x="5" y="3" width="2" height="7" fill="#8b5a2b"/>
+  </svg>`;
+  const halberdSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+    <path d="M6 0 L9 3 H3 L6 0" fill="#dcdcdc"/>
+    <rect x="5" y="3" width="2" height="7" fill="#8b5a2b"/>
+    <rect x="7" y="4" width="3" height="3" fill="#dcdcdc"/>
+  </svg>`;
+  const crossbowSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+    <rect x="5" y="1" width="2" height="9" fill="#8b5a2b"/>
+    <rect x="2" y="4" width="8" height="2" fill="#8b5a2b"/>
+    <rect x="3" y="4" width="6" height="1" fill="#dcdcdc"/>
+  </svg>`;
+  const flailSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
+    <rect x="5" y="1" width="2" height="4" fill="#8b5a2b"/>
+    <rect x="6" y="5" width="1" height="2" fill="#dcdcdc"/>
+    <rect x="5" y="7" width="4" height="4" fill="#dcdcdc"/>
+  </svg>`;
+  const katanaSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+    <path d="M2 10 L9 1" stroke="#dcdcdc" stroke-width="2"/>
+    <rect x="1" y="9" width="4" height="1" fill="#8b5a2b"/>
+  </svg>`;
+  const weaponIcons = {
+    sword: swordLootSVG,
+    bow: bowLootSVG,
+    axe: axeSVG,
+    mace: maceSVG,
+    dagger: daggerSVG,
+    wand: wandSVG,
+    staff: staffSVG,
+    spear: spearSVG,
+    halberd: halberdSVG,
+    crossbow: crossbowSVG,
+    flail: flailSVG,
+    katana: katanaSVG
+  };
+  for(const [k,svg] of Object.entries(weaponIcons)){
+    SPRITES['icon_'+k] = makeIcon(svg);
+  }
 
   // Bat idle animations 24x24
   function makeBatAnim(wing, body){

--- a/game.js
+++ b/game.js
@@ -996,8 +996,8 @@ function redrawInventory(){
   html += '<div class="equip-grid">';
   for(const slot of SLOTS){
     const it = inventory.equip[slot];
-    const label = it ? `<span style="color:${it.color}" class="item-name">${escapeHtml(it.name)}</span>` : '';
-    html += `<div class="inv-slot list-row ${it?'':'empty'}" data-type="eq" data-slot="${slot}">${label}</div>`;
+    const icon = it && it.icon ? `<canvas class="item-img" data-icon="${it.icon}"></canvas>` : '';
+    html += `<div class="inv-slot list-row ${it?'':'empty'}" data-type="eq" data-slot="${slot}">${icon}</div>`;
   }
   html += '</div>';
   html += '</div>';
@@ -1006,16 +1006,16 @@ function redrawInventory(){
   html += '<div class="potion-grid">';
   for(let i=0;i<POTION_BAG_SIZE;i++){
     const it = inventory.potionBag[i];
-    const label = it ? `<span style="color:${it.color}" class="item-name">${escapeHtml(it.name)}</span>` : '';
-    html += `<div class="inv-slot list-row ${it?'':'empty'}" data-type="pbag" data-idx="${i}">${label}</div>`;
+    const icon = it && it.icon ? `<canvas class="item-img" data-icon="${it.icon}"></canvas>` : '';
+    html += `<div class="inv-slot list-row ${it?'':'empty'}" data-type="pbag" data-idx="${i}">${icon}</div>`;
   }
   html += '</div>';
   html += '<div class="section-title">Bag</div>';
   html += '<div class="bag-grid">';
   for(let i=0;i<BAG_SIZE;i++){
     const it = inventory.bag[i];
-    const label = it ? `<span style="color:${it.color}" class="item-name">${escapeHtml(it.name)}</span>` : '';
-    html += `<div class="inv-slot list-row ${it?'':'empty'}" data-type="bag" data-idx="${i}">${label}</div>`;
+    const icon = it && it.icon ? `<canvas class="item-img" data-icon="${it.icon}"></canvas>` : '';
+    html += `<div class="inv-slot list-row ${it?'':'empty'}" data-type="bag" data-idx="${i}">${icon}</div>`;
   }
   html += '</div>';
   html += '<div class="hr"></div>';
@@ -1026,6 +1026,10 @@ function redrawInventory(){
   html += '</div>';
   html += '<div id="invCompare" class="panel"></div>';
   panel.innerHTML = html;
+  panel.querySelectorAll('canvas.item-img').forEach(c=>{
+    const key=c.dataset.icon; const spr=ASSETS.sprites[key];
+    if(spr){ c.width=c.height=32; const g=c.getContext('2d'); g.imageSmoothingEnabled=false; g.clearRect(0,0,32,32); g.drawImage(spr.cv,0,0,32,32); }
+  });
   const cmp=document.getElementById('invCompare'); if(cmp) cmp.style.display='none';
 
   const portrait = document.getElementById('invChar');
@@ -1042,7 +1046,13 @@ function redrawInventory(){
   let lastRow=null;
   panel.onmousemove = (e)=>{
     const row = e.target.closest('.list-row');
-    if(!row || row===lastRow) return;
+    if(!row){
+      if(lastRow){
+        lastRow=null; setDetailsText(INV_DETAILS_DEFAULT); disableInvActions(); showCompare(null);
+      }
+      return;
+    }
+    if(row===lastRow) return;
     lastRow=row;
     showItemDetailsFromRow(row);
   };
@@ -1266,7 +1276,7 @@ function makeRandomGear(){
   else baseName = generateItemName(base);
   const name = `${RARITY[rarityIdx].n} ${baseName}`;
   const item = { color: RARITY[rarityIdx].c, type:'gear', slot, name, rarity: rarityIdx, lvl: floorNum, mods: affixMods(slot, rarityIdx, floorNum) };
-  if(slot==='weapon'){ item.wclass = base.toLowerCase(); }
+  if(slot==='weapon'){ item.wclass = base.toLowerCase(); item.icon = 'icon_'+item.wclass; }
   else if(slot!=='ring1' && slot!=='ring2' && slot!=='necklace'){
     // Armor types provide baseline stats and defensive buffs
     const t = ARMOR_TYPES[rng.int(0, ARMOR_TYPES.length-1)];
@@ -1283,8 +1293,8 @@ function makeRandomPotion(){
   const rarityIdx = rng.int(0, RARITY.length-1);
   const p = POTION_TYPES[rng.int(0, POTION_TYPES.length-1)];
   const item = { color: RARITY[rarityIdx].c, type:'potion', slot:'Potion', name:`${RARITY[rarityIdx].n} ${p.base}`, rarity:rarityIdx };
-  if(p.k==='hp') item.hp = p.vals[rarityIdx];
-  if(p.k==='mp') item.mp = p.vals[rarityIdx];
+  if(p.k==='hp'){ item.hp = p.vals[rarityIdx]; item.icon='potion_hp'; }
+  if(p.k==='mp'){ item.mp = p.vals[rarityIdx]; item.icon='potion_mp'; }
   return item;
 }
 

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,Roboto,Ubuntu,Arial,sans-serif;overflow:hidden}
   #ui{position:fixed;inset:0;display:grid;grid-template-rows:auto 1fr auto;pointer-events:none}
   .topbar{display:flex;gap:16px;align-items:center;padding:8px 14px;background:linear-gradient(#191a1f,#111219);border-bottom:1px solid #2a2d39;transform:scale(1.1);transform-origin:top left;width:calc(100%/1.1)}
-  .panel{background:rgba(15,16,22,0.8);border:1px solid #2a2d39;border-radius:10px;box-shadow:0 0 0 1px rgba(255,255,255,0.03) inset}
+  .panel{background:rgba(15,16,22,0.9);border:1px solid #2a2d39;border-radius:10px;box-shadow:0 0 0 1px rgba(255,255,255,0.03) inset}
   .stat{height:14px;width:220px; background:#222;border:1px solid #333;border-radius:6px;position:relative}
   .fill{position:absolute;left:0;top:0;height:100%;background:#3c7}
   .fill.hp{background:#d44}
@@ -34,7 +34,8 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
 #inventory .char-portrait{width:96px;height:96px;border:1px solid #2a2d39;border-radius:6px;background:#0f1119;margin-bottom:8px;display:flex;align-items:center;justify-content:center}
   #inventory .equip-grid{display:grid;grid-template-columns:repeat(2,96px);gap:12px}
 #inventory .inv-right{flex:1;display:flex;flex-direction:column}
-  #inventory .inv-slot{width:96px;height:60px;border:1px solid #2a2d39;border-radius:6px;background:#10131c;display:flex;flex-direction:column;align-items:center;justify-content:center;cursor:pointer;box-sizing:border-box;padding:0}
+  #inventory .inv-slot{width:96px;height:60px;border:1px solid #2a2d39;border-radius:6px;background:#06080f;display:flex;flex-direction:column;align-items:center;justify-content:center;cursor:pointer;box-sizing:border-box;padding:0}
+#inventory .item-img{width:32px;height:32px;image-rendering:pixelated}
 #inventory .inv-slot.empty{opacity:.4}
   #inventory .item-name{font-size:12px;text-align:center;display:block;width:100%;padding:2px;box-sizing:border-box;white-space:normal;overflow:visible;text-overflow:clip;word-break:break-word}
   #inventory .potion-grid{display:grid;grid-template-columns:repeat(3,96px);gap:12px;margin-bottom:12px}


### PR DESCRIPTION
## Summary
- Add static icon sprites for every weapon type and wire them into item generation
- Display item icons in inventory slots and hide details when cursor leaves the item
- Darken and opacify inventory panels to highlight items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b660102e5c832286365bd5feebc7d9