### PR TITLE
Expand inventory capacity with scrollable grids

### DIFF
--- a/modules/playerInventory.js
+++ b/modules/playerInventory.js
@@ -11,8 +11,8 @@ const SLOTS = [
   "ring2",
   "weapon",
 ];
-const BAG_SIZE = 12;
-const POTION_BAG_SIZE = 3;
+const BAG_SIZE = 25;
+const POTION_BAG_SIZE = 15;
 
 class PlayerInventory {
   constructor() {

--- a/modules/saveLoad.js
+++ b/modules/saveLoad.js
@@ -56,8 +56,12 @@ function applySaveData(data = {}) {
       weapon: null,
     }
   );
-  inventory.bag = deepClone(inv.bag || new Array(BAG_SIZE).fill(null));
-  inventory.potionBag = deepClone(inv.potionBag || new Array(POTION_BAG_SIZE).fill(null));
+  inventory.bag = deepClone(inv.bag || []);
+  inventory.bag.length = BAG_SIZE;
+  for (let i = 0; i < BAG_SIZE; i++) inventory.bag[i] = inventory.bag[i] || null;
+  inventory.potionBag = deepClone(inv.potionBag || []);
+  inventory.potionBag.length = POTION_BAG_SIZE;
+  for (let i = 0; i < POTION_BAG_SIZE; i++) inventory.potionBag[i] = inventory.potionBag[i] || null;
 
   // keep player references in sync
   player.equip = inventory.equip;

--- a/style.css
+++ b/style.css
@@ -38,8 +38,8 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
 #inventory .item-img{width:32px;height:32px;image-rendering:pixelated}
 #inventory .inv-slot.empty{opacity:.4}
   #inventory .item-name{font-size:12px;text-align:center;display:block;width:100%;padding:2px;box-sizing:border-box;white-space:normal;overflow:visible;text-overflow:clip;word-break:break-word}
-  #inventory .potion-grid{display:grid;grid-template-columns:repeat(3,96px);gap:12px;margin-bottom:12px}
-  #inventory .bag-grid{display:grid;grid-template-columns:repeat(8,96px);gap:12px}
+  #inventory .potion-grid{display:grid;grid-template-columns:repeat(3,96px);gap:12px;margin-bottom:12px;max-height:144px;overflow-y:auto}
+  #inventory .bag-grid{display:grid;grid-template-columns:repeat(8,96px);gap:12px;max-height:216px;overflow-y:auto}
   #inventory #invDetails{margin-top:8px;min-height:40px}
 #inventory .inventory-footer{display:flex;gap:12px;margin-top:8px;font-size:12px}
 #inventory .inventory-footer .footer-item{display:flex;align-items:center;gap:4px}

--- a/test/save-load.test.js
+++ b/test/save-load.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { player } from '../modules/player.js';
-import { inventory, SLOTS } from '../modules/playerInventory.js';
+import { inventory, SLOTS, BAG_SIZE, POTION_BAG_SIZE } from '../modules/playerInventory.js';
 import { getSaveData, applySaveData } from '../modules/saveLoad.js';
 
 function setupState(){
@@ -48,6 +48,8 @@ test('inventory and abilities persist through save data', () => {
   assert.equal(inventory.bag[0].name, 'Health Potion');
   assert.equal(inventory.potionBag[0].name, 'Mana Potion');
   assert.equal(inventory.equip.necklace.name, 'Amulet of Tests');
+  assert.equal(inventory.bag.length, BAG_SIZE);
+  assert.equal(inventory.potionBag.length, POTION_BAG_SIZE);
   assert.equal(player.skillPoints, 2);
   assert.equal(player.magicPoints, 3);
   assert.ok(player.skills.berserkerBattle[0]);


### PR DESCRIPTION
## Summary
- Increase bag to 25 slots and potion bag to 15 slots
- Make potion and bag grids scrollable to keep inventory tidy
- Ensure save/load and tests handle expanded inventories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6626c0d24832289a997b2b108927c