### PR TITLE
Move audio and gameplay sliders to escape menu settings

### DIFF
--- a/game.js
+++ b/game.js
@@ -2679,6 +2679,10 @@ function toggleEscMenu(force){
   const menu=document.getElementById('escMenu'); if(!menu) return;
   const show=typeof force==='boolean'?force:(menu.style.display===''||menu.style.display==='none');
   menu.style.display=show?'grid':'none';
+  if(show){
+    const btn=document.getElementById('menuTabBtn');
+    if(btn) btn.click();
+  }
   updatePaused();
 }
 
@@ -2947,6 +2951,21 @@ function setupUIEvents(){
 
   const loadBtn=document.getElementById('loadBtn');
   if(loadBtn) loadBtn.addEventListener('click', loadGame);
+
+  const menuTabBtn=document.getElementById('menuTabBtn');
+  const settingsTabBtn=document.getElementById('settingsTabBtn');
+  const menuTab=document.getElementById('menuTab');
+  const settingsTab=document.getElementById('settingsTab');
+  if(menuTabBtn && settingsTabBtn && menuTab && settingsTab){
+    const showTab=tab=>{
+      menuTab.style.display = tab==='menu' ? 'block' : 'none';
+      settingsTab.style.display = tab==='settings' ? 'block' : 'none';
+      menuTabBtn.classList.toggle('active', tab==='menu');
+      settingsTabBtn.classList.toggle('active', tab==='settings');
+    };
+    menuTabBtn.addEventListener('click', ()=>showTab('menu'));
+    settingsTabBtn.addEventListener('click', ()=>showTab('settings'));
+  }
 }
 
 if(document.readyState==='loading') window.addEventListener('DOMContentLoaded', setupUIEvents);

--- a/index.html
+++ b/index.html
@@ -31,23 +31,6 @@
       <div class="hud-kv"><b>Kills:</b> <span id="hudKills">0</span></div>
       <div class="hud-kv"><b id="hudAbilityLabel">Spell:</b> <span id="hudSpell">None</span></div>
     <div class="hud-kv" id="hudDmg" style="opacity:.85;margin-left:auto">ATK 2-4 | CRIT 5% | ARM 0</div>
-    <div class="hud-kv" style="margin-left:8px; pointer-events:auto">
-      <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
-        <input type="checkbox" id="smoothToggle" checked> Smooth
-      </label>
-    </div>
-    <div class="hud-kv" style="display:flex;align-items:center;gap:6px; pointer-events:auto">
-      <label for="speedRange">Speed</label>
-      <input type="range" id="speedRange" min="60" max="220" value="140" step="5" style="width:140px">
-    </div>
-    <div class="hud-kv" style="display:flex;align-items:center;gap:4px; pointer-events:auto">
-      <label for="masterVol">Vol</label>
-      <input type="range" id="masterVol" min="0" max="1" step="0.01" value="1" style="width:80px">
-      <label for="musicVol">Mus</label>
-      <input type="range" id="musicVol" min="0" max="1" step="0.01" value="1" style="width:80px">
-      <label for="sfxVol">SFX</label>
-      <input type="range" id="sfxVol" min="0" max="1" step="0.01" value="1" style="width:80px">
-    </div>
   </div>
   <div></div>
   <div class="footer">Sprites generated at runtime — multi-file</div>
@@ -155,12 +138,37 @@
   </div>
 
 <div id="escMenu" class="stone" style="position:fixed;inset:0;display:none;place-items:center">
-  <div class="panel" style="padding:18px 22px;text-align:center">
-    <h2 style="margin:6px 0 12px 0">Paused</h2>
-    <div style="display:flex;gap:8px;flex-direction:column">
-      <button id="resumeBtn" class="btn">Resume</button>
-      <button id="saveBtn" class="btn">Save Game</button>
-      <button id="loadBtn" class="btn">Load Game</button>
+  <div class="panel" style="padding:18px 22px;text-align:center;max-width:360px">
+    <div class="tabs" style="display:flex;gap:8px;margin-bottom:8px">
+      <button id="menuTabBtn" class="btn sml tab-btn active" style="flex:1">Menu</button>
+      <button id="settingsTabBtn" class="btn sml tab-btn" style="flex:1">Settings</button>
+    </div>
+    <div id="menuTab" class="tab-content" style="display:block">
+      <h2 style="margin:6px 0 12px 0">Paused</h2>
+      <div style="display:flex;gap:8px;flex-direction:column">
+        <button id="resumeBtn" class="btn">Resume</button>
+        <button id="saveBtn" class="btn">Save Game</button>
+        <button id="loadBtn" class="btn">Load Game</button>
+      </div>
+    </div>
+    <div id="settingsTab" class="tab-content" style="display:none;text-align:left">
+      <div class="hud-kv" style="pointer-events:auto">
+        <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
+          <input type="checkbox" id="smoothToggle" checked> Smooth
+        </label>
+      </div>
+      <div class="hud-kv" style="display:flex;align-items:center;gap:6px; pointer-events:auto;margin-top:8px">
+        <label for="speedRange" style="width:60px">Speed</label>
+        <input type="range" id="speedRange" min="60" max="220" value="140" step="5" style="flex:1">
+      </div>
+      <div class="hud-kv" style="display:flex;align-items:center;gap:4px; pointer-events:auto;margin-top:8px">
+        <label for="masterVol">Vol</label>
+        <input type="range" id="masterVol" min="0" max="1" step="0.01" value="1" style="width:80px">
+        <label for="musicVol">Mus</label>
+        <input type="range" id="musicVol" min="0" max="1" step="0.01" value="1" style="width:80px">
+        <label for="sfxVol">SFX</label>
+        <input type="range" id="sfxVol" min="0" max="1" step="0.01" value="1" style="width:80px">
+      </div>
     </div>
   </div>
 </div>

--- a/style.css
+++ b/style.css
@@ -58,7 +58,8 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
   .hr{height:1px;background:#2a2d39;margin:8px -8px}
   .hint{opacity:.8}
 .actions{display:flex;gap:8px;flex-wrap:wrap}
-  .sml{padding:6px 8px;font-size:12px;border-radius:6px}
+.sml{padding:6px 8px;font-size:12px;border-radius:6px}
+.tab-btn.active{background:#1a1d2a}
   .section-title{font-weight:bold;margin:6px 0 4px}
   .item-title{font-weight:600}
   .green{color:#76d38b}


### PR DESCRIPTION
## Summary
- Replace HUD sliders with a new Settings tab inside the escape menu
- Add tab support in escape menu to switch between menu and settings
- Style active tab and default to Menu when opening

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6647247f88322953b3a8a13a14d37