### PR TITLE
Move sliders to escape menu settings tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 An offline HTML5 dungeon crawler with inline sprites, now featuring Berserker, Spellbinder and Nightblade classes, a Berserker skill tree, consumable potions and legendary gear.
 
-Recent updates rework the audio system with smoother sound effects and dynamic music that cross‑fades between calm, combat and boss themes. Players can fine‑tune overall, music and SFX volume via new sliders stored in local storage.
+Recent updates rework the audio system with smoother sound effects and dynamic music that cross‑fades between calm, combat and boss themes. Players can fine‑tune overall, music and SFX volume via new sliders stored in local storage, now accessible through the pause menu's **Settings** tab.
+Gameplay options like movement speed and minimap opacity are also adjusted from this Settings view.
 
 The game now auto-saves your current floor and equipped gear to local storage when you leave the page. Use the pause menu to manually save or load this progress.
 

--- a/game.js
+++ b/game.js
@@ -2718,6 +2718,11 @@ function toggleEscMenu(force){
   const menu=document.getElementById('escMenu'); if(!menu) return;
   const show=typeof force==='boolean'?force:(menu.style.display===''||menu.style.display==='none');
   menu.style.display=show?'grid':'none';
+  if(show){
+    const main=document.getElementById('escMainPanel');
+    const settings=document.getElementById('escSettingsPanel');
+    if(main && settings){ main.style.display='flex'; settings.style.display='none'; }
+  }
   updatePaused();
 }
 
@@ -2986,6 +2991,21 @@ function setupUIEvents(){
 
   const loadBtn=document.getElementById('loadBtn');
   if(loadBtn) loadBtn.addEventListener('click', loadGame);
+
+  const escMainTab=document.getElementById('escMainTab');
+  const escSettingsTab=document.getElementById('escSettingsTab');
+  const escMainPanel=document.getElementById('escMainPanel');
+  const escSettingsPanel=document.getElementById('escSettingsPanel');
+  if(escMainTab && escSettingsTab && escMainPanel && escSettingsPanel){
+    escMainTab.addEventListener('click', ()=>{
+      escMainPanel.style.display='flex';
+      escSettingsPanel.style.display='none';
+    });
+    escSettingsTab.addEventListener('click', ()=>{
+      escMainPanel.style.display='none';
+      escSettingsPanel.style.display='flex';
+    });
+  }
 }
 
 if(document.readyState==='loading') window.addEventListener('DOMContentLoaded', setupUIEvents);

--- a/index.html
+++ b/index.html
@@ -32,27 +32,6 @@
       <div class="hud-kv"><b>Kills:</b> <span id="hudKills">0</span></div>
       <div class="hud-kv"><b id="hudAbilityLabel">Spell:</b> <span id="hudSpell">None</span></div>
     <div class="hud-kv" id="hudDmg" style="opacity:.85;margin-left:auto">ATK 2-4 | CRIT 5% | ARM 0</div>
-    <div class="hud-kv" style="margin-left:8px; pointer-events:auto">
-      <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
-        <input type="checkbox" id="smoothToggle" checked> Smooth
-      </label>
-    </div>
-    <div class="hud-kv" style="display:flex;align-items:center;gap:6px; pointer-events:auto">
-      <label for="speedRange">Speed</label>
-      <input type="range" id="speedRange" min="60" max="220" value="140" step="5" style="width:140px">
-    </div>
-    <div class="hud-kv" style="display:flex;align-items:center;gap:4px; pointer-events:auto">
-      <label for="masterVol">Vol</label>
-      <input type="range" id="masterVol" min="0" max="1" step="0.01" value="1" style="width:80px">
-      <label for="musicVol">Mus</label>
-      <input type="range" id="musicVol" min="0" max="1" step="0.01" value="1" style="width:80px">
-      <label for="sfxVol">SFX</label>
-      <input type="range" id="sfxVol" min="0" max="1" step="0.01" value="1" style="width:80px">
-    </div>
-    <div class="hud-kv" style="display:flex;align-items:center;gap:4px; pointer-events:auto">
-      <label for="minimapOpacity">Map</label>
-      <input type="range" id="minimapOpacity" min="0.2" max="1" step="0.05" value="0.8" style="width:80px">
-    </div>
   </div>
   <div></div>
   <div class="footer">Sprites generated at runtime — multi-file</div>
@@ -162,10 +141,37 @@
 <div id="escMenu" class="stone" style="position:fixed;inset:0;display:none;place-items:center">
   <div class="panel" style="padding:18px 22px;text-align:center">
     <h2 style="margin:6px 0 12px 0">Paused</h2>
-    <div style="display:flex;gap:8px;flex-direction:column">
+    <div style="display:flex;gap:8px;justify-content:center;margin-bottom:12px">
+      <button id="escMainTab" class="btn">Main</button>
+      <button id="escSettingsTab" class="btn">Settings</button>
+    </div>
+    <div id="escMainPanel" style="display:flex;gap:8px;flex-direction:column">
       <button id="resumeBtn" class="btn">Resume</button>
       <button id="saveBtn" class="btn">Save Game</button>
       <button id="loadBtn" class="btn">Load Game</button>
+    </div>
+    <div id="escSettingsPanel" style="display:none;flex-direction:column;gap:8px;align-items:center">
+      <div class="hud-kv" style="pointer-events:auto">
+        <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
+          <input type="checkbox" id="smoothToggle" checked> Smooth
+        </label>
+      </div>
+      <div class="hud-kv" style="display:flex;align-items:center;gap:6px;pointer-events:auto">
+        <label for="speedRange">Speed</label>
+        <input type="range" id="speedRange" min="60" max="220" value="140" step="5" style="width:140px">
+      </div>
+      <div class="hud-kv" style="display:flex;align-items:center;gap:4px;pointer-events:auto">
+        <label for="masterVol">Vol</label>
+        <input type="range" id="masterVol" min="0" max="1" step="0.01" value="1" style="width:80px">
+        <label for="musicVol">Mus</label>
+        <input type="range" id="musicVol" min="0" max="1" step="0.01" value="1" style="width:80px">
+        <label for="sfxVol">SFX</label>
+        <input type="range" id="sfxVol" min="0" max="1" step="0.01" value="1" style="width:80px">
+      </div>
+      <div class="hud-kv" style="display:flex;align-items:center;gap:4px;pointer-events:auto">
+        <label for="minimapOpacity">Map</label>
+        <input type="range" id="minimapOpacity" min="0.2" max="1" step="0.05" value="0.8" style="width:80px">
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Add Settings tab to escape menu for volume, speed, minimap, and smooth movement controls
- Reset escape menu to Main tab when opened and handle tab switching
- Document new Settings tab in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b66651202883228a592590236defaf