### PR TITLE
feat: highlight inventory rarity and widen potion grid

### DIFF
--- a/game.js
+++ b/game.js
@@ -1007,7 +1007,7 @@ function redrawInventory(){
   html += '<div class="equip-grid">';
   for(const slot of SLOTS){
     const it = inventory.equip[slot];
-    const icon = it && it.icon ? `<canvas class="item-img" data-icon="${it.icon}"></canvas>` : '';
+    const icon = it && it.icon ? `<canvas class="item-img rar${it.rarity||0}" data-icon="${it.icon}"></canvas>` : '';
     html += `<div class="inv-slot list-row ${it?'':'empty'}" data-type="eq" data-slot="${slot}">${icon}</div>`;
   }
   html += '</div>';
@@ -1017,7 +1017,7 @@ function redrawInventory(){
   html += '<div class="potion-grid">';
   for(let i=0;i<POTION_BAG_SIZE;i++){
     const it = inventory.potionBag[i];
-    const icon = it && it.icon ? `<canvas class="item-img" data-icon="${it.icon}"></canvas>` : '';
+    const icon = it && it.icon ? `<canvas class="item-img rar${it.rarity||0}" data-icon="${it.icon}"></canvas>` : '';
     html += `<div class="inv-slot list-row ${it?'':'empty'}" data-type="pbag" data-idx="${i}">${icon}</div>`;
   }
   html += '</div>';
@@ -1025,7 +1025,7 @@ function redrawInventory(){
   html += '<div class="bag-grid">';
   for(let i=0;i<BAG_SIZE;i++){
     const it = inventory.bag[i];
-    const icon = it && it.icon ? `<canvas class="item-img" data-icon="${it.icon}"></canvas>` : '';
+    const icon = it && it.icon ? `<canvas class="item-img rar${it.rarity||0}" data-icon="${it.icon}"></canvas>` : '';
     html += `<div class="inv-slot list-row ${it?'':'empty'}" data-type="bag" data-idx="${i}">${icon}</div>`;
   }
   html += '</div>';

--- a/style.css
+++ b/style.css
@@ -37,9 +37,15 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
 #inventory .inv-right{flex:1;display:flex;flex-direction:column}
   #inventory .inv-slot{width:96px;height:60px;border:1px solid #2a2d39;border-radius:6px;background:#06080f;display:flex;flex-direction:column;align-items:center;justify-content:center;cursor:pointer;box-sizing:border-box;padding:0}
 #inventory .item-img{width:32px;height:32px;image-rendering:pixelated}
+#inventory .item-img.rar0{filter:drop-shadow(0 0 6px #bfbfbf)}
+#inventory .item-img.rar1{filter:drop-shadow(0 0 6px #38c172)}
+#inventory .item-img.rar2{filter:drop-shadow(0 0 6px #3490dc)}
+#inventory .item-img.rar3{filter:drop-shadow(0 0 6px #eab308)}
+#inventory .item-img.rar4{filter:drop-shadow(0 0 6px #a855f7)}
+#inventory .item-img.rar5{filter:drop-shadow(0 0 6px #f97316)}
 #inventory .inv-slot.empty{opacity:.4}
   #inventory .item-name{font-size:12px;text-align:center;display:block;width:100%;padding:2px;box-sizing:border-box;white-space:normal;overflow:visible;text-overflow:clip;word-break:break-word}
-  #inventory .potion-grid{display:grid;grid-template-columns:repeat(3,96px);gap:12px;margin-bottom:12px;max-height:144px;overflow-y:auto}
+  #inventory .potion-grid{display:grid;grid-template-columns:repeat(5,96px);gap:12px;margin-bottom:12px;max-height:216px;overflow-y:auto}
   #inventory .bag-grid{display:grid;grid-template-columns:repeat(8,96px);gap:12px;max-height:216px;overflow-y:auto}
   #inventory #invDetails{margin-top:8px;min-height:40px}
 #inventory .inventory-footer{display:flex;gap:12px;margin-top:8px;font-size:12px}


### PR DESCRIPTION
## Summary
- add drop-shadow glow to inventory icons based on item rarity
- display potions in a 5-column grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b667edc6b4832288b1e8c303054288