### PR TITLE
Add icons for ring and necklace gear

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -567,6 +567,9 @@ function genSprites(){
   </svg>`;
   SPRITES.ring_loot = makeSpinAnim(ringLootSVG);
   SPRITES.necklace_loot = makeSpinAnim(necklaceLootSVG);
+  // Static icons for inventory display
+  SPRITES.icon_ring = makeIcon(ringLootSVG);
+  SPRITES.icon_necklace = makeIcon(necklaceLootSVG);
 
   const axeSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" shape-rendering="crispEdges">
     <rect x="5" y="1" width="2" height="9" fill="#8b5a2b"/>

--- a/game.js
+++ b/game.js
@@ -1289,7 +1289,9 @@ function makeRandomGear(){
   const name = `${RARITY[rarityIdx].n} ${baseName}`;
   const item = { color: RARITY[rarityIdx].c, type:'gear', slot, name, rarity: rarityIdx, lvl: floorNum, mods: affixMods(slot, rarityIdx, floorNum) };
   if(slot==='weapon'){ item.wclass = base.toLowerCase(); item.icon = 'icon_'+item.wclass; }
-  else if(slot!=='ring1' && slot!=='ring2' && slot!=='necklace'){
+  else if(slot==='ring1' || slot==='ring2'){ item.icon = 'icon_ring'; }
+  else if(slot==='necklace'){ item.icon = 'icon_necklace'; }
+  else{
     // Armor types provide baseline stats and defensive buffs
     const t = ARMOR_TYPES[rng.int(0, ARMOR_TYPES.length-1)];
     item.armorType = t;


### PR DESCRIPTION
## Summary
- Provide static ring and necklace icons in sprites so jewelry shows in inventory
- Assign appropriate icons when generating ring and necklace gear items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b668d77524832298edeb3125fe2f37