### PR TITLE
Fix inventory hover flicker

### DIFF
--- a/game.js
+++ b/game.js
@@ -1067,17 +1067,17 @@ function redrawInventory(){
   }
 
   // events (why: keep DOM light using delegation instead of many listeners)
+  let lastHoverRow = null;
   panel.onmousemove = (e)=>{
     const row = e.target.closest('.list-row');
-    if(!row){
-      setDetailsText(INV_DETAILS_DEFAULT);
-      disableInvActions();
-      showCompare(null);
-      return;
+    if(!row){ return; }
+    if(row !== lastHoverRow){
+      lastHoverRow = row;
+      showItemDetailsFromRow(row, e);
     }
-    showItemDetailsFromRow(row, e);
   };
   panel.onmouseleave=()=>{
+    lastHoverRow = null;
     setDetailsText(INV_DETAILS_DEFAULT);
     disableInvActions();
     showCompare(null);


### PR DESCRIPTION
## Summary
- Avoid resetting inventory details when moving between items to prevent screen bounce.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b66f04e5c4832297486ac9783584bb