### PR TITLE
Reduce inventory UI size and center comparison popups

### DIFF
--- a/game.js
+++ b/game.js
@@ -1164,7 +1164,9 @@ function showCompare(it, evt, compare=true){
     html+=renderDetails(it,'bag');
   }
   cmp.innerHTML=html;
-  if(evt){ cmp.style.left=`${evt.clientX+16}px`; cmp.style.top=`${evt.clientY+16}px`; }
+  cmp.style.left='50%';
+  cmp.style.top='50%';
+  cmp.style.transform='translate(-50%,-50%)';
   cmp.style.display='block';
 }
 

--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
   .stone{background-image:linear-gradient(180deg,rgba(255,255,255,.03),rgba(0,0,0,.08));}
   .footer{padding:6px 12px;border-top:1px solid #2a2d39;background:linear-gradient(#0f1016,#0b0c11);opacity:.85}
   #bossAlert{position:fixed;top:20px;left:50%;transform:translateX(-50%);padding:8px 14px;background:#141622;border:1px solid #3a3e4d;border-radius:8px;pointer-events:none;opacity:.95;z-index:1000}
-  #inventory{display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);padding:12px;pointer-events:auto;font-size:13px;width:1100px;max-width:95vw;max-height:90vh;overflow-y:auto}
+  #inventory{display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);padding:12px;pointer-events:auto;font-size:12px;width:880px;max-width:90vw;max-height:90vh;overflow-y:auto}
   #shop{display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);min-width:320px;width:620px;max-width:90vw;max-height:70vh;overflow:auto;padding:10px 12px;pointer-events:auto;font-size:13px}
   #magic{display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);padding:8px 12px;pointer-events:auto;font-size:13px;width:340px;max-width:90vw;max-height:70vh;overflow:auto}
   #skills{display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);padding:8px 12px;pointer-events:auto;font-size:13px;width:340px;max-width:90vw;max-height:70vh;overflow:auto}
@@ -31,12 +31,12 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
 .inv-grid .list-row{flex-direction:column;gap:2px}
 
 /* New inventory layout */
-#inventory .inventory-layout{display:flex;gap:16px}
-#inventory .inv-left{width:180px;display:flex;flex-direction:column;align-items:center}
-#inventory .char-portrait{width:96px;height:96px;border:1px solid #2a2d39;border-radius:6px;background:#0f1119;margin-bottom:8px;display:flex;align-items:center;justify-content:center}
-  #inventory .equip-grid{display:grid;grid-template-columns:repeat(2,96px);gap:12px}
+#inventory .inventory-layout{display:flex;gap:12px}
+#inventory .inv-left{width:150px;display:flex;flex-direction:column;align-items:center}
+#inventory .char-portrait{width:80px;height:80px;border:1px solid #2a2d39;border-radius:6px;background:#0f1119;margin-bottom:8px;display:flex;align-items:center;justify-content:center}
+  #inventory .equip-grid{display:grid;grid-template-columns:repeat(2,80px);gap:10px}
 #inventory .inv-right{flex:1;display:flex;flex-direction:column}
-  #inventory .inv-slot{width:96px;height:60px;border:1px solid #2a2d39;border-radius:6px;background:#06080f;display:flex;flex-direction:column;align-items:center;justify-content:center;cursor:pointer;box-sizing:border-box;padding:0}
+  #inventory .inv-slot{width:80px;height:50px;border:1px solid #2a2d39;border-radius:6px;background:#06080f;display:flex;flex-direction:column;align-items:center;justify-content:center;cursor:pointer;box-sizing:border-box;padding:0}
 #inventory .item-img{width:32px;height:32px;image-rendering:pixelated}
 #inventory .item-img.rar0{filter:drop-shadow(0 0 6px #bfbfbf)}
 #inventory .item-img.rar1{filter:drop-shadow(0 0 6px #38c172)}
@@ -45,14 +45,14 @@ html,body{margin:0;background:#0b0b0e;color:#ddd;font-family:system-ui,Segoe UI,
 #inventory .item-img.rar4{filter:drop-shadow(0 0 6px #a855f7)}
 #inventory .item-img.rar5{filter:drop-shadow(0 0 6px #f97316)}
 #inventory .inv-slot.empty{opacity:.4}
-  #inventory .item-name{font-size:12px;text-align:center;display:block;width:100%;padding:2px;box-sizing:border-box;white-space:normal;overflow:visible;text-overflow:clip;word-break:break-word}
-  #inventory .potion-grid{display:grid;grid-template-columns:repeat(5,96px);gap:12px;margin-bottom:12px;max-height:216px;overflow-y:auto}
-  #inventory .bag-grid{display:grid;grid-template-columns:repeat(8,96px);gap:12px;max-height:216px;overflow-y:auto}
+  #inventory .item-name{font-size:11px;text-align:center;display:block;width:100%;padding:2px;box-sizing:border-box;white-space:normal;overflow:visible;text-overflow:clip;word-break:break-word}
+  #inventory .potion-grid{display:grid;grid-template-columns:repeat(5,80px);gap:10px;margin-bottom:12px;max-height:180px;overflow-y:auto}
+  #inventory .bag-grid{display:grid;grid-template-columns:repeat(8,80px);gap:10px;max-height:180px;overflow-y:auto}
   #inventory #invDetails{margin-top:8px;height:160px;overflow-y:auto}
 #inventory .inventory-footer{display:flex;gap:12px;margin-top:8px;font-size:12px}
 #inventory .inventory-footer .footer-item{display:flex;align-items:center;gap:4px}
   #inventory .list-row:hover{background:#1a1d28}
-  #inventory #invCompare{position:fixed;display:none;padding:8px;min-width:260px;max-width:40%;max-height:40vh;overflow:auto;pointer-events:none;z-index:1000}
+  #inventory #invCompare{position:fixed;display:none;padding:8px;min-width:260px;max-width:40%;max-height:40vh;overflow:auto;pointer-events:none;z-index:1000;left:50%;top:50%;transform:translate(-50%,-50%)}
 .skill-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:8px}
 .skill-card{display:flex;flex-direction:column;gap:4px;padding:6px;border-radius:6px}
 .skill-card:hover{background:#1a1d28}


### PR DESCRIPTION
## Summary
- Shrink inventory layout for smaller overall footprint
- Center comparison popups to keep them fully visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f65959208322ae551c7cd1605e2f