### PR TITLE
feat: add directional melee attack visuals

### DIFF
--- a/modules/player.js
+++ b/modules/player.js
@@ -16,6 +16,8 @@ const player = {
   stamAcc: 0,
   faceDx: 1,
   faceDy: 0,
+  attackTimer: 0,
+  attackDir: 'right',
   effects: []
 };
 


### PR DESCRIPTION
## Summary
- track melee attack direction and timer on the player
- render short melee swing arcs based on attack direction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b70fcba7288322a4e1ca6411d816bc