### PR TITLE
feat: add varied stone floor tiles

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -1,15 +1,47 @@
 // procedural floor and wall textures (no external assets)
-const floorTex = (() => {
-  const c = document.createElement('canvas');
-  c.width = c.height = 32;
-  const g = c.getContext('2d');
-  g.fillStyle = '#8B4513';
-  g.fillRect(0, 0, 32, 32);
-  g.fillStyle = '#A0522D';
-  g.fillRect(0, 0, 16, 16);
-  g.fillRect(16, 16, 16, 16);
-  return c;
-})();
+// generate a set of stone floor tiles with subtle crack variations
+function makeFloorTiles(count = 16) {
+  const tiles = [];
+  for (let i = 0; i < count; i++) {
+    const c = document.createElement('canvas');
+    c.width = c.height = 32;
+    const g = c.getContext('2d');
+    // base stone color and border
+    g.fillStyle = '#5c5d60';
+    g.fillRect(0, 0, 32, 32);
+    g.strokeStyle = '#2f3033';
+    g.lineWidth = 2;
+    g.strokeRect(0, 0, 32, 32);
+
+    // inner lighter area
+    g.fillStyle = '#6d6e72';
+    g.fillRect(2, 2, 28, 28);
+
+    // deterministic pseudo-random cracks
+    let s = i * 1234567;
+    function rnd() {
+      s = (s * 1664525 + 1013904223) | 0;
+      return (s >>> 0) / 4294967296;
+    }
+    g.strokeStyle = '#3c3d40';
+    g.lineWidth = 1;
+    const cracks = 2 + (rnd() * 3) | 0; // 2-4 cracks
+    for (let j = 0; j < cracks; j++) {
+      const sx = 4 + rnd() * 24;
+      const sy = 4 + rnd() * 24;
+      const ex = sx + (rnd() * 2 - 1) * 8;
+      const ey = sy + (rnd() * 2 - 1) * 8;
+      g.beginPath();
+      g.moveTo(sx, sy);
+      g.lineTo(ex, ey);
+      g.stroke();
+    }
+
+    tiles.push(c);
+  }
+  return tiles;
+}
+const floorTiles = makeFloorTiles();
 const wallTex = (() => {
   const c = document.createElement('canvas');
   c.width = c.height = 32;
@@ -24,7 +56,7 @@ const wallTex = (() => {
 
 // Collect textures under a descriptive object so they can be tweaked from one place
 const TEXTURES = {
-  floor: floorTex,
+  floorTiles,
   wall: wallTex,
 };
 

--- a/game.js
+++ b/game.js
@@ -665,14 +665,22 @@ function buildLayers(){
   floorLayer=document.createElement('canvas'); floorLayer.width=MAP_W*TILE; floorLayer.height=MAP_H*TILE;
   wallLayer=document.createElement('canvas'); wallLayer.width=MAP_W*TILE; wallLayer.height=MAP_H*TILE;
   const f=floorLayer.getContext('2d'), w=wallLayer.getContext('2d');
-  f.fillStyle=f.createPattern(ASSETS.textures.floor,'repeat'); f.fillRect(0,0,floorLayer.width,floorLayer.height);
-  // mask non-floor
-  const mask=document.createElement('canvas'); mask.width=floorLayer.width; mask.height=floorLayer.height;
-  const mg=mask.getContext('2d'); mg.fillStyle='#000'; mg.fillRect(0,0,mask.width,mask.height);
-  mg.globalCompositeOperation='destination-out';
-  mg.fillStyle='#fff';
-  for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++) if(map[y*MAP_W+x]===T_FLOOR||map[y*MAP_W+x]===T_TRAP||map[y*MAP_W+x]===T_LAVA){ mg.fillRect(x*TILE,y*TILE,TILE,TILE); }
-  f.drawImage(mask,0,0);
+
+  const tiles=ASSETS.textures.floorTiles;
+  for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++){
+    const idx=y*MAP_W+x;
+    const t=map[idx];
+    if(t!==T_FLOOR && t!==T_TRAP && t!==T_LAVA) continue;
+    const h=((x*73856093)^(y*19349663)^seed)>>>0;
+    const tile=tiles[h%tiles.length];
+    const rot=(h>>4)&3;
+    f.save();
+    f.translate(x*TILE+TILE/2,y*TILE+TILE/2);
+    f.rotate(rot*Math.PI/2);
+    f.drawImage(tile,-TILE/2,-TILE/2);
+    f.restore();
+  }
+
   f.globalCompositeOperation='multiply';
   for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++){
     const idx=y*MAP_W+x;
@@ -685,6 +693,7 @@ function buildLayers(){
     f.fillRect(x*TILE,y*TILE,TILE,TILE);
   }
   f.globalCompositeOperation='source-over';
+
   // walls
   w.fillStyle=w.createPattern(ASSETS.textures.wall,'repeat');
   for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++) if(map[y*MAP_W+x]===T_WALL) w.fillRect(x*TILE,y*TILE,TILE,TILE);


### PR DESCRIPTION
## Summary
- generate stone floor tile variants procedurally
- draw floor tiles with per-tile random rotation for visual variety

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b723dbefec8322ab0bf2f04d907a3c