### PR TITLE
Add rat idle and attack animations

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -241,23 +241,29 @@ function genSprites(){
   SPRITES.slime_purple = loadSlimeAnim('#b84aff');
   SPRITES.slime_shadow = loadSlimeAnim('#3a3a3a');
 
-  // Rat animation frames loaded from external assets
+  // Rat animation frames loaded from external assets (idle, move, attack)
   function loadRatAnim(){
-    const frames = [];
-    for(let i=0;i<5;i++){
-      const img = new Image();
-      img.src = `assets/Rat/Frames/Move/${String(i).padStart(2,'0')}.png`;
-      const c = document.createElement('canvas');
-      c.width = c.height = 32;
-      const g = c.getContext('2d');
-      g.imageSmoothingEnabled = false;
-      img.onload = () => {
-        g.clearRect(0,0,32,32);
-        g.drawImage(img,0,0);
-      };
-      frames.push(c);
+    function loadSet(folder, count){
+      const frames = [];
+      for(let i=0;i<count;i++){
+        const img = new Image();
+        img.src = `assets/Rat/Frames/${folder}/${String(i).padStart(2,'0')}.png`;
+        const c = document.createElement('canvas');
+        c.width = c.height = 32;
+        const g = c.getContext('2d');
+        g.imageSmoothingEnabled = false;
+        img.onload = () => {
+          g.clearRect(0,0,32,32);
+          g.drawImage(img,0,0);
+        };
+        frames.push(c);
+      }
+      return frames;
     }
-    return { cv: frames[0], frames };
+    const idle = loadSet('Idle_rat_frames',5);
+    const move = loadSet('Move',5);
+    const attack = loadSet('Attack',4);
+    return { idle, move, attack, cv: idle[0] };
   }
   SPRITES.rat = loadRatAnim();
 

--- a/game.js
+++ b/game.js
@@ -2086,10 +2086,21 @@ function draw(dt){
     const mx = mtx*TILE - camX + (TILE-size)/2; const my = mty*TILE - camY + (TILE-size)/2;
     const key = m.spriteKey || (m.type===0?'slime' : m.type===1?'bat' : m.type===2?'skeleton' : m.type===5?'goblin' : m.type===6?'ghost' : m.type===7?'invader' : m.type===8?'chomper' : m.type===9?'rat' : 'mage');
     const spr = ASSETS.sprites[key];
-    let frame = spr.cv;
-    if(spr.frames && spr.frames.length>0){
+    let frame;
+    if(spr.attack && m.attackAnim>0){
+      const idx = Math.floor((6 - m.attackAnim) * spr.attack.length / 7);
+      frame = spr.attack[Math.min(idx, spr.attack.length - 1)];
+    } else if(spr.move && m.moving){
+      const anim = spr.move;
+      frame = anim[Math.floor(now/200) % anim.length];
+    } else if(spr.idle){
+      const anim = spr.idle;
+      frame = anim[Math.floor(now/200) % anim.length];
+    } else if(spr.frames && spr.frames.length>0){
       const animIdx = Math.floor(now/200) % spr.frames.length;
       frame = spr.frames[animIdx];
+    } else {
+      frame = spr.cv;
     }
     if(m.elite || m.miniBoss || m.bigBoss){
       const pulse = 0.5 + 0.5*Math.sin(now*0.002);


### PR DESCRIPTION
## Summary
- Load rat idle, move, and attack frame sets from asset folder
- Render rats with appropriate animation based on movement or attack state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85c588554832287ef7f3a0a093089