### PR TITLE
Add rat movement, idle and attack animations

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -243,7 +243,22 @@ function genSprites(){
 
   // Rat animation frames loaded from external assets
   function loadRatAnim(){
-    const frames = [];
+    const idle = [], move = [], attack = [];
+    // idle frames
+    for(let i=0;i<5;i++){
+      const img = new Image();
+      img.src = `assets/Rat/Frames/Idle_rat_frames/${String(i).padStart(2,'0')}.png`;
+      const c = document.createElement('canvas');
+      c.width = c.height = 32;
+      const g = c.getContext('2d');
+      g.imageSmoothingEnabled = false;
+      img.onload = () => {
+        g.clearRect(0,0,32,32);
+        g.drawImage(img,0,0);
+      };
+      idle.push(c);
+    }
+    // move frames
     for(let i=0;i<5;i++){
       const img = new Image();
       img.src = `assets/Rat/Frames/Move/${String(i).padStart(2,'0')}.png`;
@@ -255,9 +270,23 @@ function genSprites(){
         g.clearRect(0,0,32,32);
         g.drawImage(img,0,0);
       };
-      frames.push(c);
+      move.push(c);
     }
-    return { cv: frames[0], frames };
+    // attack frames
+    for(let i=0;i<4;i++){
+      const img = new Image();
+      img.src = `assets/Rat/Frames/Attack/${String(i).padStart(2,'0')}.png`;
+      const c = document.createElement('canvas');
+      c.width = c.height = 32;
+      const g = c.getContext('2d');
+      g.imageSmoothingEnabled = false;
+      img.onload = () => {
+        g.clearRect(0,0,32,32);
+        g.drawImage(img,0,0);
+      };
+      attack.push(c);
+    }
+    return { cv: idle[0], idle, move, attack, frames: move };
   }
   SPRITES.rat = loadRatAnim();
 

--- a/game.js
+++ b/game.js
@@ -643,6 +643,7 @@ function spawnMonster(type,x,y,elite=false){
   m.resPoison = elemRes;
   m.resMagic = magicRes;
   if(spriteKey) m.spriteKey = spriteKey;
+  if(type===9) m.spriteSize = 32; // rat uses 32x32 frames
   return m;
 }
 
@@ -2097,6 +2098,10 @@ function draw(dt){
       const prog = (6 - m.attackAnim) / 6;
       const animIdx = Math.min(spr.attack.length-1, Math.floor(prog * spr.attack.length));
       frame = spr.attack[animIdx];
+    }else if(spr.move || spr.idle){
+      const anim = m.moving ? (spr.move || spr.idle) : (spr.idle || spr.move);
+      const animIdx = Math.floor(now/200) % anim.length;
+      frame = anim[animIdx];
     }else if(spr.frames && spr.frames.length>0){
       const animIdx = Math.floor(now/200) % spr.frames.length;
       frame = spr.frames[animIdx];


### PR DESCRIPTION
## Summary
- load idle, move, and attack frames for the rat enemy
- render monsters with separate idle and movement animations
- size rat sprite to 32px so frames draw correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85d63747c8322910e095d67ba5c69