### PR TITLE
Bust cache for chest sprites

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -663,9 +663,10 @@ function genSprites(){
   SPRITES.chests = {};
   for(const v of chestVariants){
     const closed = new Image();
-    closed.src = `assets/Static/${v}_chest_closed.png`;
+    // Bust browser cache so updated art is always loaded
+    closed.src = `assets/Static/${v}_chest_closed.png?v=1`;
     const open = new Image();
-    open.src = `assets/Static/${v}_chest_open.png`;
+    open.src = `assets/Static/${v}_chest_open.png?v=1`;
     SPRITES.chests[v] = { closed, open };
   }
 


### PR DESCRIPTION
## Summary
- Prevent browsers from serving stale treasure chest art by appending a cache-busting query string to chest sprite sources.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85f2b43508322881dddb676f8f3db