### PR TITLE
fix: render chest spawns with open and closed sprites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 
 *(See the Aug 26 commit list for merged PRs #19–#29 that introduced these features and fixes.)*
 
+## 2025-09-03
+### Changed
+- Chest spawns now display bronze, silver, and golden closed sprites and swap to open sprites when looted.
+
 ## 2025-08-25
 ### Added
 - Initial single-file HTML5 dungeon game with inline sprites. (9a70473)

--- a/game.js
+++ b/game.js
@@ -943,8 +943,9 @@ function spawnChests(){
     if(lootMap.has(key)){ attempts++; continue; }
     const isMimic = rng.int(1,600) === 1;
     const variants = ['bronze','silver','golden'];
+    const colors = { bronze:'#cd7f32', silver:'#c0c0c0', golden:'#ffd700' };
     const variant = variants[rng.int(0, variants.length-1)];
-    lootMap.set(key,{type:'chest', color:'#b8860b', mimic:isMimic, variant, opened:false});
+    lootMap.set(key,{type:'chest', color:colors[variant], mimic:isMimic, variant, opened:false});
     placed++;
   }
 }
@@ -1903,6 +1904,14 @@ function monsterAI(m, dt){
 // ===== Drawing =====
 function drawLootIcon(it, x, y, size = 14){
   ctx.save();
+  if(it.type==='chest'){
+    const variant = ASSETS.sprites.chests[it.variant] ? it.variant : 'bronze';
+    const spr = ASSETS.sprites.chests[variant];
+    const img = it.opened ? spr.open : spr.closed;
+    ctx.drawImage(img, x, y, size, size);
+    ctx.restore();
+    return;
+  }
   if(it.rarity>0){
     ctx.shadowColor = it.color;
     ctx.shadowBlur = 4 + it.rarity*2;
@@ -1919,11 +1928,6 @@ function drawLootIcon(it, x, y, size = 14){
     const frames = spr.frames;
     const idx = frames.length ? Math.floor(performance.now()/100)%frames.length : 0;
     ctx.drawImage(frames[idx]||spr.cv, x+1, y+1);
-  }else if(it.type==='chest'){
-    const variant = ASSETS.sprites.chests[it.variant] ? it.variant : 'bronze';
-    const spr = ASSETS.sprites.chests[variant];
-    const img = it.opened ? spr.open : spr.closed;
-    ctx.drawImage(img, x, y, size, size);
   }else{
     switch(it.slot){
       case 'weapon':


### PR DESCRIPTION
## Summary
- draw treasure chests using bronze/silver/golden closed sprites and switch to open sprite after looting
- color chests based on variant for appropriate drop glow
- document chest sprite update in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8614bf79083228270ce951b1fb0d1