### PR TITLE
Fix class skill tree not updated on game start

### DIFF
--- a/game.js
+++ b/game.js
@@ -3157,6 +3157,7 @@ function startGame(){
   // class pick -> sprite & stats
   const cSel = document.querySelector('input[name="class"]:checked');
   player.class = cSel ? cSel.value : 'warrior';
+  player.skillTree = skillTreeGraph[player.class];
   player.boundSpell=null; player.boundSkill=null;
   updatePlayerSprite();
   player.score=0; player.kills=0; player.timeSurvived=0; player.floorsCleared=0;


### PR DESCRIPTION
## Summary
- Ensure player skill tree matches selected class when starting the game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8ca8ba1b483228accc009c92cc061