### PR TITLE
fix: serve static files reliably

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,7 +20,8 @@ const mimeTypes = {
 };
 
 const server = http.createServer(async (req, res) => {
-  const filePath = join(__dirname, req.url === '/' ? 'index.html' : req.url);
+  const requested = req.url === '/' ? '/index.html' : req.url;
+  const filePath = join(__dirname, '.' + requested);
   try {
     const data = await readFile(filePath);
     const type = mimeTypes[extname(filePath).toLowerCase()] || 'application/octet-stream';


### PR DESCRIPTION
## Summary
- ensure server resolves requested paths relative to project directory

## Testing
- `npm test`
- `curl -i http://localhost:3000/game.js | head`


------
https://chatgpt.com/codex/tasks/task_e_68b8cd11f3ec8322b3ada195b4623f83