### PR TITLE
Load weapon manifest via fetch and add default favicon

### DIFF
--- a/game.js
+++ b/game.js
@@ -13,7 +13,12 @@ import { renderLayers } from './modules/rendering.js';
 import { MIN_ROOM_SIZE, connectRooms, pruneSmallAreas } from './modules/mapGen.js';
 import { createNoise2D } from './modules/noise.js';
 import { ARMOR_TYPES, ARMOR_TYPE_MODS } from './modules/armorTypes.js';
-import weaponManifest from './assets/weaponManifest.json' assert { type: 'json' };
+// Load weapon manifest JSON without using import assertions for wider browser support
+let weaponManifest = {};
+fetch('./assets/weaponManifest.json')
+  .then(r => r.json())
+  .then(data => weaponManifest = data)
+  .catch(err => console.error('Failed to load weapon manifest', err));
 
 // ===== Config / Globals =====
 let VIEW_W=window.innerWidth, VIEW_H=window.innerHeight;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1.0" />
 <title>Dungeon — Sprites + Gender + Shop/Stairs</title>
 <link rel="stylesheet" href="style.css">
+<link rel="icon" href="data:,">
 </head>
 <body>
 <canvas id="gameCanvas"></canvas>


### PR DESCRIPTION
## Summary
- Replace JSON import assertion with fetch to load weapon manifest in browsers lacking import assertion support
- Add inline blank favicon to avoid 404 requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8dc5ea3688322b20338c0e8d28486