### PR TITLE
Colorized melee slash effect

### DIFF
--- a/modules/player.js
+++ b/modules/player.js
@@ -18,6 +18,7 @@ const player = {
   faceDy: 0,
   attackTimer: 0,
   attackDir: 'right',
+  attackColor: '#fff',
   effects: []
 };
 


### PR DESCRIPTION
## Summary
- color map for damage types
- show melee slash effect tinted by attack's element

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a92b03b48322834d18c9c1088e76