### PR TITLE
Random themed floor tiles for each level

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -41,6 +41,35 @@ function makeFloorTiles(count = 16) {
   }
   return tiles;
 }
+
+// load external floor tile sets (4x 16x16 sprites each)
+const floorTileSets = {};
+function loadFloorTileSet(name, file) {
+  const img = new Image();
+  img.src = 'assets/' + file;
+  img.onload = () => {
+    const tiles = [];
+    const cols = Math.floor(img.width / 16);
+    for (let i = 0; i < 4; i++) {
+      const sx = (i % cols) * 16;
+      const sy = Math.floor(i / cols) * 16;
+      const c = document.createElement('canvas');
+      c.width = c.height = 32;
+      const g = c.getContext('2d');
+      g.imageSmoothingEnabled = false;
+      g.drawImage(img, sx, sy, 16, 16, 0, 0, 32, 32);
+      tiles.push(c);
+    }
+    floorTileSets[name] = tiles;
+  };
+}
+
+loadFloorTileSet('graybrick', 'floor_graybrick.png');
+loadFloorTileSet('graystone', 'floor_graystone.png');
+loadFloorTileSet('greenmoss', 'floor_greenmoss.png');
+loadFloorTileSet('ice', 'floor_ice.png');
+loadFloorTileSet('lava', 'floor_lava.png');
+
 // generate enough variations to include newly added patterns
 const floorTiles = makeFloorTiles(32);
 const wallTex = (() => {
@@ -59,6 +88,7 @@ const wallTex = (() => {
 const TEXTURES = {
   floorTiles,
   wall: wallTex,
+  floorTileSets,
 };
 
 // ====== Sprites (generated at runtime) ======

--- a/game.js
+++ b/game.js
@@ -72,6 +72,14 @@ window.addEventListener('resize', resizeCanvas); resizeCanvas();
 let camX=0, camY=0; let floorLayer=null, wallLayer=null;
 let zoom=1;
 let floorTint='#ffffff', wallTint='#ffffff';
+const FLOOR_THEMES=[
+  {name:'graybrick',wall:'#7d7d7d'},
+  {name:'graystone',wall:'#6e6e6e'},
+  {name:'greenmoss',wall:'#556b2f'},
+  {name:'ice',wall:'#9ed0ff'},
+  {name:'lava',wall:'#b44d26'},
+];
+let currentFloorTiles=ASSETS.textures.floorTiles;
 let gameOver=false;
 let paused=false;
 let scoreUpdateTimer=0;
@@ -544,14 +552,10 @@ function checkHazard(x,y){
 function generate(){
   resetMapState();
   monsters=[]; projectiles=[]; breakables=[]; lootMap.clear(); player.effects = [];
-  const hue=rng.int(0,360);
-  const sat=8+rng.int(0,8);
-  const baseLight=35+rng.int(-5,5);
-  const light=Math.min(100,Math.round(baseLight*1.1));
-  floorTint=`hsl(${hue}, ${sat}%, ${light}%)`;
-  const wallHue=(hue + rng.int(-20,20) + 360)%360;
-  const wallLight=Math.max(10, light-5);
-  wallTint=`hsl(${wallHue}, ${sat}%, ${wallLight}%)`;
+  const theme=FLOOR_THEMES[rng.int(0,FLOOR_THEMES.length-1)];
+  currentFloorTiles=ASSETS.textures.floorTileSets[theme.name]||ASSETS.textures.floorTiles;
+  floorTint='#ffffff';
+  wallTint=theme.wall;
   const r=rng.next();
   if(r<0.33) generateNoiseTerrain();
   else if(r<0.66) generateCave();
@@ -726,7 +730,7 @@ function buildLayers(){
   wallLayer=document.createElement('canvas'); wallLayer.width=MAP_W*TILE; wallLayer.height=MAP_H*TILE;
   const f=floorLayer.getContext('2d'), w=wallLayer.getContext('2d');
 
-  const tiles=ASSETS.textures.floorTiles;
+  const tiles=currentFloorTiles;
   for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++){
     const idx=y*MAP_W+x;
     const t=map[idx];


### PR DESCRIPTION
## Summary
- load floor tile images and build tile sets
- randomly choose a floor tile theme per level and tint walls to match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e257ada08322ab950fdfb609ec58