### PR TITLE
refactor: remove procedural floor tile generation

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -1,47 +1,4 @@
-// procedural floor and wall textures (no external assets)
-// generate a set of stone floor tiles with subtle crack variations
-function makeFloorTiles(count = 16) {
-  const tiles = [];
-  for (let i = 0; i < count; i++) {
-    const c = document.createElement('canvas');
-    c.width = c.height = 32;
-    const g = c.getContext('2d');
-    // base stone color and border
-    g.fillStyle = '#5c5d60';
-    g.fillRect(0, 0, 32, 32);
-    g.strokeStyle = '#2f3033';
-    g.lineWidth = 2;
-    g.strokeRect(0, 0, 32, 32);
-
-    // inner lighter area
-    g.fillStyle = '#6d6e72';
-    g.fillRect(2, 2, 28, 28);
-
-    // deterministic pseudo-random cracks
-    let s = i * 1234567;
-    function rnd() {
-      s = (s * 1664525 + 1013904223) | 0;
-      return (s >>> 0) / 4294967296;
-    }
-    g.strokeStyle = '#3c3d40';
-    g.lineWidth = 1;
-    const cracks = 2 + (rnd() * 3) | 0; // 2-4 cracks
-    for (let j = 0; j < cracks; j++) {
-      const sx = 4 + rnd() * 24;
-      const sy = 4 + rnd() * 24;
-      const ex = sx + (rnd() * 2 - 1) * 8;
-      const ey = sy + (rnd() * 2 - 1) * 8;
-      g.beginPath();
-      g.moveTo(sx, sy);
-      g.lineTo(ex, ey);
-      g.stroke();
-    }
-
-    tiles.push(c);
-  }
-  return tiles;
-}
-
+// floor and wall textures (external tile sets only)
 // load external floor tile sets (4x 16x16 sprites each)
 const floorTileSets = {};
 function loadFloorTileSet(name, file) {
@@ -70,8 +27,6 @@ loadFloorTileSet('greenmoss', 'floor_greenmoss.png');
 loadFloorTileSet('ice', 'floor_ice.png');
 loadFloorTileSet('lava', 'floor_lava.png');
 
-// generate enough variations to include newly added patterns
-const floorTiles = makeFloorTiles(32);
 const wallTex = (() => {
   const c = document.createElement('canvas');
   c.width = c.height = 32;
@@ -86,7 +41,6 @@ const wallTex = (() => {
 
 // Collect textures under a descriptive object so they can be tweaked from one place
 const TEXTURES = {
-  floorTiles,
   wall: wallTex,
   floorTileSets,
 };

--- a/game.js
+++ b/game.js
@@ -79,7 +79,7 @@ const FLOOR_THEMES=[
   {name:'ice',wall:'#9ed0ff'},
   {name:'lava',wall:'#b44d26'},
 ];
-let currentFloorTiles=ASSETS.textures.floorTiles;
+let currentFloorTiles=ASSETS.textures.floorTileSets.graybrick || [];
 let gameOver=false;
 let paused=false;
 let scoreUpdateTimer=0;
@@ -553,7 +553,7 @@ function generate(){
   resetMapState();
   monsters=[]; projectiles=[]; breakables=[]; lootMap.clear(); player.effects = [];
   const theme=FLOOR_THEMES[rng.int(0,FLOOR_THEMES.length-1)];
-  currentFloorTiles=ASSETS.textures.floorTileSets[theme.name]||ASSETS.textures.floorTiles;
+  currentFloorTiles=ASSETS.textures.floorTileSets[theme.name] || ASSETS.textures.floorTileSets.graybrick || [];
   floorTint='#ffffff';
   wallTint=theme.wall;
   const r=rng.next();
@@ -729,34 +729,35 @@ function buildLayers(){
   floorLayer=document.createElement('canvas'); floorLayer.width=MAP_W*TILE; floorLayer.height=MAP_H*TILE;
   wallLayer=document.createElement('canvas'); wallLayer.width=MAP_W*TILE; wallLayer.height=MAP_H*TILE;
   const f=floorLayer.getContext('2d'), w=wallLayer.getContext('2d');
-
   const tiles=currentFloorTiles;
-  for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++){
-    const idx=y*MAP_W+x;
-    const t=map[idx];
-    if(t!==T_FLOOR && t!==T_TRAP && t!==T_LAVA) continue;
-    const h=((x*73856093)^(y*19349663)^seed)>>>0;
-    const tile=tiles[h%tiles.length];
-    const rot=(h>>4)&3;
-    f.save();
-    f.translate(x*TILE+TILE/2,y*TILE+TILE/2);
-    f.rotate(rot*Math.PI/2);
-    f.drawImage(tile,-TILE/2,-TILE/2);
-    f.restore();
-  }
+  if(tiles.length){
+    for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++){
+      const idx=y*MAP_W+x;
+      const t=map[idx];
+      if(t!==T_FLOOR && t!==T_TRAP && t!==T_LAVA) continue;
+      const h=((x*73856093)^(y*19349663)^seed)>>>0;
+      const tile=tiles[h%tiles.length];
+      const rot=(h>>4)&3;
+      f.save();
+      f.translate(x*TILE+TILE/2,y*TILE+TILE/2);
+      f.rotate(rot*Math.PI/2);
+      f.drawImage(tile,-TILE/2,-TILE/2);
+      f.restore();
+    }
 
-  f.globalCompositeOperation='multiply';
-  for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++){
-    const idx=y*MAP_W+x;
-    if(map[idx]!==T_FLOOR && map[idx]!==T_TRAP && map[idx]!==T_LAVA) continue;
-    let col=floorTint;
-    const b=biomeMap[idx];
-    if(b===B_DESERT) col='#d7c67f';
-    else if(b===B_MOUNTAIN) col='#c2c2c2';
-    f.fillStyle=col;
-    f.fillRect(x*TILE,y*TILE,TILE,TILE);
+    f.globalCompositeOperation='multiply';
+    for(let y=0;y<MAP_H;y++) for(let x=0;x<MAP_W;x++){
+      const idx=y*MAP_W+x;
+      if(map[idx]!==T_FLOOR && map[idx]!==T_TRAP && map[idx]!==T_LAVA) continue;
+      let col=floorTint;
+      const b=biomeMap[idx];
+      if(b===B_DESERT) col='#d7c67f';
+      else if(b===B_MOUNTAIN) col='#c2c2c2';
+      f.fillStyle=col;
+      f.fillRect(x*TILE,y*TILE,TILE,TILE);
+    }
+    f.globalCompositeOperation='source-over';
   }
-  f.globalCompositeOperation='source-over';
 
   // walls
   w.fillStyle=w.createPattern(ASSETS.textures.wall,'repeat');


### PR DESCRIPTION
## Summary
- drop old procedural floor tile generation
- default floor tiles to external tile sets
- guard rendering against missing tile data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e410edf483229d6f67042d5bcbe7