### PR TITLE
Add dragon boss variants

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -1014,6 +1014,58 @@ function genSprites(){
   }
   SPRITES.griffin = makeGriffinAnim();
 
+  // Dragon animations loaded from sprite sheets
+  function loadDragonAnim(type){
+    const idle=[], damage=[], death=[];
+    const sprite={ cv: document.createElement('canvas'), idle, move: idle, damage, death };
+    sprite.cv.width = sprite.cv.height = 64;
+    const base = 'assets/dragon_sprites/'+type;
+
+    const idleImg = new Image();
+    idleImg.src = base + '_idle.png';
+    idleImg.onload = () => {
+      const frameW = Math.floor(idleImg.width/5);
+      const frameH = idleImg.height;
+      for(let i=0;i<5;i++){
+        const c=document.createElement('canvas'); c.width=frameW; c.height=frameH;
+        const g=c.getContext('2d'); g.imageSmoothingEnabled=false;
+        g.drawImage(idleImg,i*frameW,0,frameW,frameH,0,0,frameW,frameH);
+        idle.push(c);
+      }
+      sprite.cv = idle[0];
+    };
+
+    const dmgImg = new Image();
+    dmgImg.src = base + '_damage.png';
+    dmgImg.onload = () => {
+      const frameW = Math.floor(dmgImg.width/9);
+      const frameH = dmgImg.height;
+      for(let i=0;i<9;i++){
+        const c=document.createElement('canvas'); c.width=frameW; c.height=frameH;
+        const g=c.getContext('2d'); g.imageSmoothingEnabled=false;
+        g.drawImage(dmgImg,i*frameW,0,frameW,frameH,0,0,frameW,frameH);
+        damage.push(c);
+      }
+    };
+
+    const deathImg = new Image();
+    deathImg.src = base + '_death.png';
+    deathImg.onload = () => {
+      const frameW = Math.floor(deathImg.width/17);
+      const frameH = deathImg.height;
+      for(let i=0;i<17;i++){
+        const c=document.createElement('canvas'); c.width=frameW; c.height=frameH;
+        const g=c.getContext('2d'); g.imageSmoothingEnabled=false;
+        g.drawImage(deathImg,i*frameW,0,frameW,frameH,0,0,frameW,frameH);
+        death.push(c);
+      }
+    };
+
+    return sprite;
+  }
+
+  SPRITES.dragon_fire = loadDragonAnim('fire');
+  SPRITES.dragon_ice = loadDragonAnim('ice');
 
   // Invader alien 24x24 (retro space shooter homage)
   SPRITES.invader = makeSprite(24,(g,S)=>{

--- a/modules/config.js
+++ b/modules/config.js
@@ -27,7 +27,7 @@ export const SCORE_PER_FLOOR_CLEAR = 100;
 export const SCORE_PER_FLOOR_REACHED = 50;
 
 // Mega boss variant
-export const BOSS_VARIANTS = ['griffin'];
+export const BOSS_VARIANTS = ['griffin', 'dragon_fire', 'dragon_ice'];
 export const XP_GAIN_MULT = 1.1;
 export const ENEMY_SPEED_MULT = 1.5;
 export const MONSTER_HP_MULT = 1.2;


### PR DESCRIPTION
## Summary
- Add fire and ice dragons as possible boss variants
- Load dragon sprite sheets to provide idle, damage, and death animations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e5be080c8322acb3eff8ab0d3e96