### PR TITLE
Fix floor tile asset path

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -3,7 +3,8 @@
 const floorTileSets = {};
 function loadFloorTileSet(name, file) {
   const img = new Image();
-  img.src = 'assets/' + file;
+  // floor tile images live under assets/floor_tiles
+  img.src = 'assets/floor_tiles/' + file;
   img.onload = () => {
     const tiles = [];
     const cols = Math.floor(img.width / 16);


### PR DESCRIPTION
## Summary
- Load floor tile sets from the correct `assets/floor_tiles` directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e872bc90832291cd8fc79c5f3e5b