### PR TITLE
Ensure floor textures use 16x16 sprites

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -4,7 +4,6 @@ const floorTileSets = {};
 function loadFloorTileSet(name, file) {
   const img = new Image();
   // floor tile images live under assets/floor_tiles
-  img.src = 'assets/floor_tiles/' + file;
   img.onload = () => {
     const tiles = [];
     const cols = Math.floor(img.width / 16);
@@ -23,6 +22,8 @@ function loadFloorTileSet(name, file) {
       window.onFloorTilesLoaded(name, tiles);
     }
   };
+  // set src after onload to avoid missing cached load events
+  img.src = 'assets/floor_tiles/' + file;
 }
 
 loadFloorTileSet('graybrick', 'floor_graybrick.png');


### PR DESCRIPTION
## Summary
- Fix floor tile loading by registering image onload handlers before assigning `src`
- Prevent missing floor textures caused by cached image loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9ea4086688322b268804c7279d696