### PR TITLE
Fix floor texture loading

### DIFF
--- a/assets/sprites.js
+++ b/assets/sprites.js
@@ -1,6 +1,7 @@
 // floor and wall textures (external tile sets only)
 // load external floor tile sets (4x 16x16 sprites each)
 const floorTileSets = {};
+const floorTileQueue = [];
 function loadFloorTileSet(name, file) {
   const img = new Image();
   // floor tile images live under assets/floor_tiles
@@ -20,6 +21,8 @@ function loadFloorTileSet(name, file) {
     floorTileSets[name] = tiles;
     if (typeof window.onFloorTilesLoaded === 'function') {
       window.onFloorTilesLoaded(name, tiles);
+    } else {
+      floorTileQueue.push({ name, tiles });
     }
   };
   // set src after onload to avoid missing cached load events
@@ -1266,3 +1269,4 @@ genSprites();
 // expose a single global for game code and modders
 const ASSETS = { textures: TEXTURES, sprites: SPRITES };
 globalThis.ASSETS = ASSETS;
+globalThis.__floorTileQueue = floorTileQueue;

--- a/game.js
+++ b/game.js
@@ -116,6 +116,13 @@ window.onFloorTilesLoaded = () => {
   if (floorLayer) buildLayers();
 };
 
+if (globalThis.__floorTileQueue && globalThis.__floorTileQueue.length) {
+  for (const _ of globalThis.__floorTileQueue) {
+    window.onFloorTilesLoaded();
+  }
+  globalThis.__floorTileQueue.length = 0;
+}
+
 
 // --- Smooth helpers & settings ---
 function smoothstep01(t){ return t*t*(3-2*t); }


### PR DESCRIPTION
## Summary
- Queue floor tiles when assets load before game code
- Process queued tile sets so levels draw with provided floor textures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9edfb2094832283305885c096af95